### PR TITLE
fix(nvim): Fix Ansible deploying in wrong directory or with bad permissions

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -3,6 +3,8 @@
 # Devbox Ansible Role default Vars
 #
 
+devbox_user_home: /home/mrzzy
+
 devbox_nvim_version: 0.4.3-3
 devbox_nvim_vim_plug_version: 0.11.0
 

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -22,8 +22,8 @@
     - name: Unmark repo as bare to allow checkouts
       community.general.git_config:
         name: core.bare
-        scope: local
-        repo: "{{ devbox_user_home }}"
+        scope: file
+        file: "{{ devbox_user_home }}/.git/config"
         state: absent
 
     - name: Checkout dotfiles

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -7,6 +7,14 @@
 - name: Install Development Tooling
   import_tasks: tooling/install.yaml
 
+- name: Pull dotfiles repository
+  git:
+    repo: https://github.com/mrzzy/dotfiles
+    version: main
+    single_branch: true
+    dest: "{{ devbox_user_home }}/.git"
+    bare: true
+
 - name: Setup Neovim
   become: true
   import_tasks: setup_nvim.yaml
@@ -14,36 +22,36 @@
 - name: Setup User Accounts & Permissions
   become: true
   block:
-  - name: Create groups
-    group:
-      name: "{{ item }}"
-      state: present
-    loop:
-      - sudo
-      - docker
-
-  - name: Create mrzzy user
-    user:
-      name: mrzzy
-      comment: "Zhu Zhanyan"
-      home: "{{ devbox_user_home }}"
-      groups:
-        # sudo group for passwordless sudo
+    - name: Create groups
+      group:
+        name: "{{ item }}"
+        state: present
+      loop:
         - sudo
-        # docker group for sudo-free access to the docker CLI
         - docker
 
-  - name: Allow password-less sudo to users in sudo group
-    copy:
-      content: "%sudo ALL=(ALL:ALL) NOPASSWD:ALL"
-      dest: /etc/sudoers.d/sudo_nopasswd
-      mode: 0440
+    - name: Create mrzzy user
+      user:
+        name: mrzzy
+        comment: "Zhu Zhanyan"
+        home: "{{ devbox_user_home }}"
+        groups:
+          # sudo group for passwordless sudo
+          - sudo
+          # docker group for sudo-free access to the docker CLI
+          - docker
 
-  - name: Fix owner of devbox home directory
-    become: true
-    file:
-      path: "{{ devbox_user_home }}"
-      owner: mrzzy
-      group: mrzzy
-      state: directory
-      recurse: true
+    - name: Allow password-less sudo to users in sudo group
+      copy:
+        content: "%sudo ALL=(ALL:ALL) NOPASSWD:ALL"
+        dest: /etc/sudoers.d/sudo_nopasswd
+        mode: 0440
+
+    - name: Fix owner of devbox home directory
+      become: true
+      file:
+        path: "{{ devbox_user_home }}"
+        owner: mrzzy
+        group: mrzzy
+        state: directory
+        recurse: true

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -3,24 +3,41 @@
 # Devbox Ansible Role Tasks
 #
 
+# add customized dotfiles
+- name: Install dotfiles
+  become: true
+  block:
+    - name: Pull bare dotfiles repository
+      git:
+        repo: https://github.com/mrzzy/dotfiles
+        version: main
+        single_branch: true
+        dest: "{{ devbox_user_home }}/.git"
+        bare: true
+
+    - name: Unmark repo as bare to allow checkouts
+      community.general.git_config:
+        name: core.bare
+        scope: local
+        repo: "{{ devbox_user_home }}"
+        state: absent
+
+    - name: Checkout dotfiles
+      command: # noqa command-instead-of-module
+        cmd: "git checkout"
+        chdir: "{{ devbox_user_home }}"
+      register: checkout
+      changed_when: "{{ checkout.rc == 0 }}"
+
 # setup development tooling
 - name: Install Development Tooling
   import_tasks: tooling/install.yaml
-
-- name: Pull dotfiles repository
-  # root required to create repo under /home
-  become: true
-  git:
-    repo: https://github.com/mrzzy/dotfiles
-    version: main
-    single_branch: true
-    dest: "{{ devbox_user_home }}/.git"
-    bare: true
 
 - name: Setup Neovim
   become: true
   import_tasks: setup_nvim.yaml
 
+# create user & permissions
 - name: Setup User Accounts & Permissions
   become: true
   block:

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -8,6 +8,8 @@
   import_tasks: tooling/install.yaml
 
 - name: Pull dotfiles repository
+  # root required to create repo under /home
+  become: true
   git:
     repo: https://github.com/mrzzy/dotfiles
     version: main
@@ -48,7 +50,6 @@
         mode: 0440
 
     - name: Fix owner of devbox home directory
-      become: true
       file:
         path: "{{ devbox_user_home }}"
         owner: mrzzy

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -3,6 +3,15 @@
 # Devbox Ansible Role Tasks
 #
 
+# setup development tooling
+- name: Install Development Tooling
+  import_tasks: tooling/install.yaml
+
+- name: Setup Neovim
+  become: true
+  import_tasks: setup_nvim.yaml
+
+
 # add customized dotfiles
 - name: Install dotfiles
   become: true
@@ -28,14 +37,6 @@
         chdir: "{{ devbox_user_home }}"
       register: checkout
       changed_when: "{{ checkout.rc == 0 }}"
-
-# setup development tooling
-- name: Install Development Tooling
-  import_tasks: tooling/install.yaml
-
-- name: Setup Neovim
-  become: true
-  import_tasks: setup_nvim.yaml
 
 # create user & permissions
 - name: Setup User Accounts & Permissions

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -3,8 +3,13 @@
 # Devbox Ansible Role Tasks
 #
 
+# setup development tooling
 - name: Install Development Tooling
   import_tasks: tooling/install.yaml
+
+- name: Setup Neovim
+  become: true
+  import_tasks: setup_nvim.yaml
 
 - name: Setup User Accounts & Permissions
   become: true
@@ -34,7 +39,11 @@
       dest: /etc/sudoers.d/sudo_nopasswd
       mode: 0440
 
-# setup development tooling
-- name: Setup Neovim
-  become_user: mrzzy
-  import_tasks: setup_nvim.yaml
+  - name: Fix owner of devbox home directory
+    become: true
+    file:
+      path: "{{ devbox_user_home }}"
+      owner: mrzzy
+      group: mrzzy
+      state: directory
+      recurse: true

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -3,14 +3,9 @@
 # Devbox Ansible Role Tasks
 #
 
-# setup development tooling
+# install development tooling
 - name: Install Development Tooling
   import_tasks: tooling/install.yaml
-
-- name: Setup Neovim
-  become: true
-  import_tasks: setup_nvim.yaml
-
 
 # add customized dotfiles
 - name: Install dotfiles
@@ -33,10 +28,15 @@
 
     - name: Checkout dotfiles
       command: # noqa command-instead-of-module
-        cmd: "git checkout"
+        cmd: git checkout
         chdir: "{{ devbox_user_home }}"
       register: checkout
-      changed_when: "{{ checkout.rc == 0 }}"
+      changed_when: checkout.rc == 0
+
+# setup development tooling
+- name: Setup Neovim
+  become: true
+  import_tasks: setup_nvim.yaml
 
 # create user & permissions
 - name: Setup User Accounts & Permissions

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -21,6 +21,7 @@
     user:
       name: mrzzy
       comment: "Zhu Zhanyan"
+      home: "{{ devbox_user_home }}"
       groups:
         # sudo group for passwordless sudo
         - sudo

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -26,6 +26,13 @@
         file: "{{ devbox_user_home }}/.git/config"
         state: absent
 
+    # workaround git security patch for CVE-2022-24765
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    - name: Trust non-owned repository
+      community.general.git_config:
+        name: safe.directory
+        value: "{{ devbox_user_home }}"
+
     - name: Checkout dotfiles
       command: # noqa command-instead-of-module
         cmd: git checkout

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -20,6 +20,11 @@
     dest: "{{ devbox_user_home }}/.local/share/nvim/site/autoload/plug.vim"
 
 - name: Install Neovim Plugins
+  # direct plugins to be installed in mrzzy's home dir
+  environment:
+    XDG_CONFIG_HOME: "{{ devbox_user_home }}/.config"
+    XDG_DATA_HOME: "{{ devbox_user_home }}/.local/share"
+    XDG_STATE_HOME: "{{ devbox_user_home }}/.local/state"
   command:
-    cmd: "nvim -u {{ devbox_user_home }}/.config/nvim/init.vim +PlugInstall +qall"
+    cmd: nvim --headless +PlugInstall +qall
     creates: "{{ devbox_user_home }}/.local/share/nvim/plugged"

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -11,21 +11,21 @@
     state: directory
     mode: 0774
   loop:
-    - ~/.config/nvim/
-    - ~/.local/share/nvim/site/autoload/
+    - "{{ devbox_user_home }}/.config/nvim/"
+    - "{{ devbox_user_home }}/.local/share/nvim/site/autoload/"
 
 - name: Pull Neovim config from github.com/mrzzy/dotfiles
   get_url:
     url: https://raw.githubusercontent.com/mrzzy/dotfiles/main/.config/nvim/init.vim
-    dest: ~/.config/nvim/init.vim
+    dest: "{{ devbox_user_home }}/.config/nvim/init.vim"
 
 # Configure Plugins
 - name: Install vim-plug plugin manager
   get_url:
     url: https://raw.githubusercontent.com/junegunn/vim-plug/{{ devbox_nvim_vim_plug_version }}/plug.vim
-    dest: ~/.local/share/nvim/site/autoload/plug.vim
+    dest: "{{ devbox_user_home }}/.local/share/nvim/site/autoload/plug.vim"
 
 - name: Install Neovim Plugins
   command:
     cmd: nvim +PlugInstall +qall
-    creates: ~/.local/share/nvim/plugged
+    creates: "{{ devbox_user_home }}/.local/share/nvim/plugged"

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -11,17 +11,7 @@
     state: directory
     mode: 0774
   loop:
-    - "{{ devbox_user_home }}/.config/nvim/"
     - "{{ devbox_user_home }}/.local/share/nvim/site/autoload/"
-
-- name: Checkout Neovim dotfiles
-  # use command instead of git mod as the latter does not support checking out specific paths.
-  command:
-    chdir: "{{ devbox_user_home }}"
-    cmd: git checkout .config/nvim
-    creates: "{{ devbox_user_home }}/.config/nvim"
-  tags:
-    - skip_ansible_lint
 
 # Configure Plugins
 - name: Install vim-plug plugin manager

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -14,10 +14,14 @@
     - "{{ devbox_user_home }}/.config/nvim/"
     - "{{ devbox_user_home }}/.local/share/nvim/site/autoload/"
 
-- name: Pull Neovim config from github.com/mrzzy/dotfiles
-  get_url:
-    url: https://raw.githubusercontent.com/mrzzy/dotfiles/main/.config/nvim/init.vim
-    dest: "{{ devbox_user_home }}/.config/nvim/init.vim"
+- name: Checkout Neovim dotfiles
+  # use command instead of git mod as the latter does not support checking out specific paths.
+  command:
+    chdir: "{{ devbox_user_home }}"
+    cmd: git checkout .config/nvim
+    creates: "{{ devbox_user_home }}/.config/nvim"
+  tags:
+    - skip_ansible_lint
 
 # Configure Plugins
 - name: Install vim-plug plugin manager

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -21,5 +21,5 @@
 
 - name: Install Neovim Plugins
   command:
-    cmd: nvim +PlugInstall +qall
+    cmd: "nvim -u {{ devbox_user_home }}/.config/nvim/init.vim +PlugInstall +qall"
     creates: "{{ devbox_user_home }}/.local/share/nvim/plugged"

--- a/box/packer/image.pkr.hcl
+++ b/box/packer/image.pkr.hcl
@@ -39,9 +39,12 @@ build {
     extra_arguments = ["-vv"]
     playbook_file   = "box/ansible/playbook.yaml"
 
-    # config ansible to output human readable logs
     ansible_env_vars = [
-      "ANSIBLE_LOAD_CALLBACK_PLUGINS=debug"
+      # config ansible to output human readable logs
+      "ANSIBLE_LOAD_CALLBACK_PLUGINS=debug",
+      # put ansible tmpdir in tmpfs when provisioning on remote machine
+      # to avoid permission issues.
+      "ANSIBLE_REMOTE_TMP=/tmp/ansible"
     ]
   }
 }


### PR DESCRIPTION
# Purpose
Inspecting WARP box deployed on GCP, I noticed that `nvim` was not picking up any config or plugins.
- Ansible was not deploying to the `mrzzy` user.
- Change in file structure in https://github.com/mrzzy/dotfiles/commit/dd68b36c9325143005e7d6566657e929e758b723 caused some dotfiles to be missed.

# Contents
Fix Ansible deploying in wrong directory or with bad permissions.
- Direct Ansible explicitly to deploy in `/home/mrzzy/`.
- Change owner of files to `mrzzy` on `/home/mrzzy/` 
- Set XDG environment variables to direct neovim to load the correct `init.vim` and install plugins in `/home/mrzzy/`

Pull dotfiles with `git checkout` instead of `get-url`
- Allows us to pull directories instead of the 1 by 1 model offered by `get-url`.

Install neovim plugins in headless mode to avoid WARP box image [build hanging](https://github.com/mrzzy/warp/actions/runs/24398431330) waiting for interactive user input.
