### PR TITLE
feat(box): Add Tmux screen multiplexer to WARP Box

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -19,6 +19,8 @@ devbox_zsh_version: 5.8-3ubuntu1.1
 devbox_zsh_autosuggest_version: 0.6.4-1
 devbox_zsh_syntax_version: 0.6.0-3
 
+devbox_tmux_version: 3.0a-2ubuntu0.3
+
 devbox_hashicorp_terraform_version: 0.15.5
 devbox_hashicorp_packer_version: 1.8.0
 

--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -14,6 +14,7 @@ devbox_docker_version: 20.10.12-0ubuntu2~20.04.1
 devbox_docker_compose_version: 1.25.0-1
 devbox_ranger_version: 1.9.3-1build1
 devbox_ansible_version: 5.8.0-1ppa~focal
+devbox_gawk_version: 1:5.0.1+dfsg-1
 
 devbox_zsh_version: 5.8-3ubuntu1.1
 devbox_zsh_autosuggest_version: 0.6.4-1

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -45,6 +45,10 @@
   become: true
   import_tasks: setup_nvim.yaml
 
+- name: Setup Tmux
+  become: true
+  import_tasks: setup_tmux.yaml
+
 # create user & permissions
 - name: Setup User Accounts & Permissions
   become: true

--- a/box/ansible/roles/devbox/tasks/setup_tmux.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_tmux.yaml
@@ -1,0 +1,23 @@
+#
+# WARP
+# Devbox Ansible Role Tasks
+# Setup Tmux
+#
+
+- name: Install Tmux Plugins
+  vars:
+    tpm_path: "{{ devbox_user_home }}/.local/share/tmux/tpm"
+  block:
+    - name: Install Tmux Plugin Manager (TPM)
+      git:
+        repo: https://github.com/tmux-plugins/tpm
+        path: "{{ tpm_path }}"
+        version: main
+        single_branch: true
+
+    - name: Run TPM install_plugins
+      environment:
+        TMUX_PLUGIN_MANAGER_PATH: "{{ tpm_path }}"
+      command:
+        cmd: "{{ tpm_path }}/bin/install_plugins"
+        creates: "{{ tpm_path }}/plugins"

--- a/box/ansible/roles/devbox/tasks/setup_tmux.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_tmux.yaml
@@ -11,13 +11,13 @@
     - name: Install Tmux Plugin Manager (TPM)
       git:
         repo: https://github.com/tmux-plugins/tpm
-        path: "{{ tpm_path }}"
-        version: main
+        dest: "{{ tpm_path }}"
+        version: master
         single_branch: true
 
     - name: Run TPM install_plugins
       environment:
-        TMUX_PLUGIN_MANAGER_PATH: "{{ tpm_path }}"
+        TMUX_PLUGIN_MANAGER_PATH: "{{ tpm_path }}/plugins"
       command:
         cmd: "{{ tpm_path }}/bin/install_plugins"
         creates: "{{ tpm_path }}/plugins"

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -35,6 +35,7 @@
     - "zsh-autosuggestions={{ devbox_zsh_autosuggest_version }} "
     - "zsh-syntax-highlighting={{ devbox_zsh_syntax_version }}"
     - "tmux={{ devbox_tmux_version }}"
+    - "gawk={{ devbox_gawk_version }}"
     # since the version of nodejs offered by registered repo is already pegged
     # there is no need to peg the version of nodejs installed here.
     - "nodejs"

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -34,7 +34,7 @@
     - "zsh={{ devbox_zsh_version }}"
     - "zsh-autosuggestions={{ devbox_zsh_autosuggest_version }} "
     - "zsh-syntax-highlighting={{ devbox_zsh_syntax_version }}"
-
+    - "tmux={{ devbox_tmux_version }}"
     # since the version of nodejs offered by registered repo is already pegged
     # there is no need to peg the version of nodejs installed here.
     - "nodejs"


### PR DESCRIPTION
# Purpose
Allow a single terminal window to be multiplexed to support multiple running multiple processes.
-  This is useful as the development workflow often calls for editor to run side by side a build, debugger or manpage.

# Contents
Add Tmux screen multiplexer to WARP Box;
- install `tmux` multiplexer.
- install `tpm` tmux plugin manager.
- add [tmux-fingers](https://github.com/Morantron/tmux-fingers) plugin for vimium hints like copy & paste.