### PR TITLE
feat(box): Embed ttyd for Web Terminal Access to WARP

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -29,6 +29,8 @@ devbox_hashicorp_packer_version: 1.8.0
 
 devbox_fzf_version: 0.29.0
 
+devbox_ttyd_version: 1.6.3
+
 # python & tools
 devbox_python_version: 3.8.2-0ubuntu2
 devbox_python_pip_version: 20.0.2-5ubuntu1.6

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -67,6 +67,8 @@
 
 - name: Install TTYD Web Terminal
   become: true
+  vars:
+    ttyd_path: /usr/local/bin/ttyd
   import_tasks: install_ttyd.yaml
 
 - name: Install tools from HashiCorp's Repository with APT"

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -65,6 +65,10 @@
     zsh_scripts_dir: "{{ devbox_user_home }}/.local/share/zsh"
   import_tasks: install_z_jump.yaml
 
+- name: Install TTYD Web Terminal
+  become: true
+  import_tasks: install_ttyd.yaml
+
 - name: Install tools from HashiCorp's Repository with APT"
   import_tasks: install_hashicorp.yaml
   vars:

--- a/box/ansible/roles/devbox/tasks/tooling/install_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install_ttyd.yaml
@@ -1,0 +1,11 @@
+#
+# WARP
+# Devbox Ansible Role Tasks
+# Install ttyd Web Terminal
+#
+
+- name: Download pre-built TTYD Binary
+  get_url:
+    url: "https://github.com/tsl0922/ttyd/releases/download/{{ devbox_ttyd_version }}/ttyd.x86_64"
+    dest: /usr/local/bin/ttyd
+    mode: 0755

--- a/box/ansible/roles/devbox/tasks/tooling/install_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install_ttyd.yaml
@@ -7,5 +7,31 @@
 - name: Download pre-built TTYD Binary
   get_url:
     url: "https://github.com/tsl0922/ttyd/releases/download/{{ devbox_ttyd_version }}/ttyd.x86_64"
-    dest: /usr/local/bin/ttyd
+    dest: "{{ ttyd_path }}"
     mode: 0755
+
+- name: Activate systemd service to start TTYD on boot
+  block:
+    - name: Write systemd service
+      copy:
+        content: |
+          [Unit]
+          Description=TTYD enables shell access a web termina
+
+          [Install]
+          WantedBy=multi-user.target
+
+          [Service]
+          Type=simple
+          ExecStart={{ ttyd_path }} --port 7681 /usr/bin/zsh
+          User=mrzzy
+          Group=mrzzy
+          WorkingDirectory=/home/mrzzy
+        dest: /etc/systemd/system/ttyd.service
+        mode: 0644
+
+    - name: Activate systemd service
+      systemd:
+        name: ttyd
+        state: started
+        enabled: true


### PR DESCRIPTION
# Purpose
Closes: #17 

# Contents
Embeds `ttyd` for Web Terminal Access to WARP:
- Install `ttyd` in WARP.
- Create a `systemd` service to run `ttyd` on boot.