### PR TITLE
feat(box): Expose WARP VM Web Terminal over HTTP

### DIFF
--- a/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
@@ -63,7 +63,7 @@
         dest: /etc/systemd/system/ttyd-http.service
         mode: 0644
 
-    - name: Activate TTYD systemd service
+    - name: Activate TTYD systemd services
       systemd:
         name: "{{ item }}"
         enabled: true

--- a/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
@@ -46,6 +46,7 @@
 
           [Install]
           WantedBy=multi-user.target
+          After=ttyd-https.service
 
           [Service]
           Type=simple

--- a/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
@@ -38,7 +38,35 @@
         dest: /etc/systemd/system/ttyd-https.service
         mode: 0644
 
+    - name: Write TTYD over HTTP systemd service
+      copy:
+        content: |
+          [Unit]
+          Description=TTYD enables shell access a web terminal over HTTP
+
+          [Install]
+          WantedBy=multi-user.target
+
+          [Service]
+          Type=simple
+          WorkingDirectory={{ devbox_user_home }}
+          # start ttyd on a unprivilleged port as the unprivilleged devbox user
+          ExecStart=sudo --user {{ devbox_user }} --group {{ devbox_user }} --login -n \
+            {{ devbox_ttyd_path }} \
+              --port 7682 \
+              /usr/bin/zsh
+
+          # use iptables to redirect HTTP traffic to the web terminal
+          ExecStartPost=iptables -A PREROUTING -t nat -p tcp --dport 80 -j REDIRECT --to-port 7682
+          ExecStopPost=iptables -D PREROUTING -t nat -p tcp --dport 80 -j REDIRECT --to-port 7682
+
+        dest: /etc/systemd/system/ttyd-http.service
+        mode: 0644
+
     - name: Activate TTYD systemd service
       systemd:
-        name: ttyd-https
+        name: "{{ item }}"
         enabled: true
+      loop:
+        - ttyd-https
+        - ttyd-http

--- a/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
@@ -4,14 +4,14 @@
 # Setup ttyd Web Terminal
 #
 
-- name: Setup systemd service to run TTYD on boot
+- name: Setup systemd services to run TTYD on boot
   become: true
   block:
-    - name: Write TTYD systemd service
+    - name: Write TTYD over HTTPS systemd service
       copy:
         content: |
           [Unit]
-          Description=TTYD enables shell access a web terminal
+          Description=TTYD enables shell access a web terminal over HTTPS
           ConditionPathExists={{ devbox_ttyd_tls_cert }}
           ConditionPathExists={{ devbox_ttyd_tls_private_key }}
 
@@ -35,10 +35,10 @@
           ExecStartPost=iptables -A PREROUTING -t nat -p tcp --dport 443 -j REDIRECT --to-port 7681
           ExecStopPost=iptables -D PREROUTING -t nat -p tcp --dport 443 -j REDIRECT --to-port 7681
 
-        dest: /etc/systemd/system/ttyd.service
+        dest: /etc/systemd/system/ttyd-https.service
         mode: 0644
 
     - name: Activate TTYD systemd service
       systemd:
-        name: ttyd
+        name: ttyd-https
         enabled: true


### PR DESCRIPTION
# Purpose
Closes: #21 

# Contents
Expose WARP VM Web Terminal over HTTP:
- create systemd service `ttyd-http` to serve a plaintext HTTP web terminal over port 80.
