### PR TITLE
fix(box): Race condition applying iptables rules

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -44,6 +44,10 @@ devbox_ttyd_tls_cert: /etc/ssl/certs/ttyd.pem
 devbox_ttyd_tls_private_key: /etc/ssl/private/ttyd.key
 # password for the ttyd web terminal. If unset disables TTYD web terminal.
 devbox_ttyd_password: ""
+# ports to instruct ttyd listen for connections
+devbox_ttyd_http_port: 7682
+devbox_ttyd_https_port: 7681
+
 
 # python & tools
 devbox_python_version: 3.8.2-0ubuntu2

--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -9,6 +9,8 @@ devbox_user_home: /home/mrzzy
 # system tools
 # needed for add-apt-repository
 devbox_software_properties_version: 0.99.9.8
+# load iptables rules on boot
+devbox_iptables_persistent_version: 1.0.14ubuntu1
 
 # language-agnostic tools
 devbox_nvim_version: 0.4.3-3

--- a/box/ansible/roles/devbox/tasks/install_system.yaml
+++ b/box/ansible/roles/devbox/tasks/install_system.yaml
@@ -5,14 +5,17 @@
 #
 
 - name: Download pre-built TTYD Binary
+  become: true
   get_url:
     url: "https://github.com/tsl0922/ttyd/releases/download/{{ devbox_ttyd_version }}/ttyd.x86_64"
     dest: "{{ devbox_ttyd_path }}"
     mode: 0755
 
 - name: Install system utilities with TTYD
+  become: true
   apt:
     name: "{{ item }}"
     state: present
   loop:
     - "software-properties-common={{ devbox_software_properties_version }}"
+    - "iptables-persistent={{ devbox_iptables_persistent_version }}"

--- a/box/ansible/roles/devbox/tasks/install_system.yaml
+++ b/box/ansible/roles/devbox/tasks/install_system.yaml
@@ -1,7 +1,7 @@
 #
 # WARP
 # Devbox Ansible Role Tasks
-# Install ttyd Web Terminal
+# Install system utilities
 #
 
 - name: Download pre-built TTYD Binary
@@ -9,3 +9,10 @@
     url: "https://github.com/tsl0922/ttyd/releases/download/{{ devbox_ttyd_version }}/ttyd.x86_64"
     dest: "{{ devbox_ttyd_path }}"
     mode: 0755
+
+- name: Install system utilities with TTYD
+  apt:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - "software-properties-common={{ devbox_software_properties_version }}"

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -6,7 +6,6 @@
 # Install
 # install system utilities
 - name: Install System Utilities
-  become: true
   import_tasks: install_system.yaml
 
 # install development tooling

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -3,6 +3,12 @@
 # Devbox Ansible Role Tasks
 #
 
+# update apt lists for installing packages
+- name: Update APT Cache
+  become: true
+  apt:
+    update-cache: true
+
 # Install
 # install system utilities
 - name: Install System Utilities

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -59,6 +59,9 @@
   when: devbox_ttyd_password != ""
   tags:
     - test
+# write iptables rules
+- name: Write iptables rules
+  import_tasks: write_iptables.yaml
 
 # setup development tooling
 - name: Setup Neovim

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -4,10 +4,10 @@
 #
 
 # Install
-# install ttyd web terminal
-- name: Install TTYD Web Terminal
+# install system utilities
+- name: Install System Utilities
   become: true
-  import_tasks: install_ttyd.yaml
+  import_tasks: install_system.yaml
 
 # install development tooling
 - name: Install Development Tooling

--- a/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_ttyd.yaml
@@ -6,9 +6,6 @@
 
 - name: Setup systemd services to run TTYD on boot
   become: true
-  vars:
-    # forward incoming traffic via the default ipv4 interface to TTYD
-    interface: "{{ ansible_default_ipv4.interface }}"
   block:
     - name: Write TTYD over HTTPS systemd service
       copy:
@@ -27,17 +24,12 @@
           # start ttyd on a unprivilleged port as the unprivilleged devbox user
           ExecStart=sudo --user {{ devbox_user }} --group {{ devbox_user }} --login -n \
             {{ devbox_ttyd_path }} \
-              --port 7681 \
+              --port {{ devbox_ttyd_https_port }} \
               --credential "{{ devbox_user }}:{{ devbox_ttyd_password }}" \
               --ssl \
               --ssl-cert {{ devbox_ttyd_tls_cert }} \
               --ssl-key {{ devbox_ttyd_tls_private_key }} \
               /usr/bin/zsh
-
-          # use iptables to redirect HTTPs traffic to the web terminal
-          ExecStartPost=iptables -A PREROUTING -t nat -p tcp -i {{ interface }} --dport 443 -j REDIRECT --to-port 7681
-          ExecStopPost=iptables -D PREROUTING -t nat -p tcp -i {{ interface }} --dport 443 -j REDIRECT --to-port 7681
-
         dest: /etc/systemd/system/ttyd-https.service
         mode: 0644
 
@@ -57,13 +49,8 @@
           # start ttyd on a unprivilleged port as the unprivilleged devbox user
           ExecStart=sudo --user {{ devbox_user }} --group {{ devbox_user }} --login -n \
             {{ devbox_ttyd_path }} \
-              --port 7682 \
+              --port {{ devbox_ttyd_http_port }} \
               /usr/bin/zsh
-
-          # use iptables to redirect HTTP traffic to the web terminal
-          ExecStartPost=iptables -A PREROUTING -t nat -p tcp -i {{ interface }} --dport 80 -j REDIRECT --to-port 7682
-          ExecStopPost=iptables -D PREROUTING -t nat -p tcp -i {{ interface }} --dport 80 -j REDIRECT --to-port 7682
-
         dest: /etc/systemd/system/ttyd-http.service
         mode: 0644
 

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -19,15 +19,11 @@
     update-cache: true
 
 - name: Install development tools with APT
-  tags: [test]
   become: true
   apt:
     name: "{{ item }}"
     state: present
   loop:
-    # system tools
-    - "software-properties-common={{ devbox_software_properties_version }}"
-
     # language-agnostic tools
     - "entr={{ devbox_entr_version }}"
     - "ripgrep={{ devbox_ripgrep_version }}"

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -13,11 +13,6 @@
 - name: Register NodeJS Repo
   include_tasks: register_nodejs.yaml
 
-- name: Update APT Cache
-  become: true
-  apt:
-    update-cache: true
-
 - name: Install development tools with APT
   become: true
   apt:

--- a/box/ansible/roles/devbox/tasks/write_iptables.yaml
+++ b/box/ansible/roles/devbox/tasks/write_iptables.yaml
@@ -5,6 +5,7 @@
 #
 
 - name: Write IPV4 iptables rules to be loaded on boot
+  become: true
   vars:
     interface: "{{ ansible_default_ipv4.interface }}"
   copy:

--- a/box/ansible/roles/devbox/tasks/write_iptables.yaml
+++ b/box/ansible/roles/devbox/tasks/write_iptables.yaml
@@ -1,0 +1,18 @@
+#
+# WARP
+# Devbox Ansible Role
+# Write iptables rules
+#
+
+- name: Write IPV4 iptables rules to be loaded on boot
+  vars:
+    interface: "{{ ansible_default_ipv4.interface }}"
+  copy:
+    content: |
+      *nat
+      # forward incoming traffic via the default ipv4 interface to TTYD
+      -A PREROUTING -i {{ interface }} -p tcp -m tcp --dport 80 -j REDIRECT --to-ports {{ devbox_ttyd_http_port }}
+      -A PREROUTING -i {{ interface }} -p tcp -m tcp --dport 443 -j REDIRECT --to-ports {{ devbox_ttyd_https_port }}
+      COMMIT
+    dest: /etc/iptables/rules.v4
+    mode: 0644


### PR DESCRIPTION
# Purpose
Fixes race condition creating `iptables` rules between `ttyd-https` & `ttyd-http`  systemd services.
- When conditions are right, contention over the `iptables` lock creates the following error:
```
iptables: Another app is currently holding the xtables lock
```

# Contents
Fix race condition applying `iptables` rules:
- install `iptables-persistent` to load `iptables` IPV4 rules form `/etc/iptables/rules.v4` on boot.
- adds `write_iptables.yaml` to write TTYD iptables rules to `/etc/iptables/rules.v4`
  - this replaces the current use of `ExecStartPre` & `ExecStopPost` hooks to apply iptables rules.

Refactor:
- use Ansible Vars to deduplicate TTYD port numbers.
- rename `install_ttyd.yaml` to `install_system.yaml` to reflect that it installs system utilities.
