### PR TITLE
fix(box): Tmux Plugins not installing in Devbox User Home Dir

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -11,6 +11,8 @@ devbox_user_home: /home/mrzzy
 devbox_software_properties_version: 0.99.9.8
 # load iptables rules on boot
 devbox_iptables_persistent_version: 1.0.14ubuntu1
+# needed for ansible to become a unprivilleged user
+devbox_acl_version: 2.2.53-6
 
 # language-agnostic tools
 devbox_nvim_version: 0.4.3-3

--- a/box/ansible/roles/devbox/tasks/install_system.yaml
+++ b/box/ansible/roles/devbox/tasks/install_system.yaml
@@ -19,3 +19,4 @@
   loop:
     - "software-properties-common={{ devbox_software_properties_version }}"
     - "iptables-persistent={{ devbox_iptables_persistent_version }}"
+    - "acl={{ devbox_acl_version }}"

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -29,7 +29,6 @@
         single_branch: true
         dest: "{{ devbox_user_home }}/.git"
         bare: true
-
     - name: Unmark repo as bare to allow checkouts
       community.general.git_config:
         name: core.bare
@@ -57,8 +56,7 @@
   include_tasks: setup_ttyd.yaml
   # disable ttyd if password is unset to avoid exposing an unauthenticated web shell
   when: devbox_ttyd_password != ""
-  tags:
-    - test
+
 # write iptables rules
 - name: Write iptables rules
   import_tasks: write_iptables.yaml

--- a/box/ansible/roles/devbox/tasks/setup_nvim.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_nvim.yaml
@@ -14,10 +14,6 @@
     - "{{ devbox_user_home }}/.local/share/nvim/site/autoload/"
 
 # Configure Plugins
-- name: Install Python client for plugins
-  pip:
-    name: "pynvim=={{ devbox_nvim_pynvim_version }}"
-
 - name: Install vim-plug plugin manager
   get_url:
     url: https://raw.githubusercontent.com/junegunn/vim-plug/{{ devbox_nvim_vim_plug_version }}/plug.vim

--- a/box/ansible/roles/devbox/tasks/setup_tmux.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_tmux.yaml
@@ -16,8 +16,6 @@
         single_branch: true
 
     - name: Run TPM install_plugins
-      environment:
-        TMUX_PLUGIN_MANAGER_PATH: "{{ tpm_path }}/plugins"
       command:
         cmd: "{{ tpm_path }}/bin/install_plugins"
         creates: "{{ tpm_path }}/plugins"

--- a/box/ansible/roles/devbox/tasks/setup_tmux.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_tmux.yaml
@@ -16,6 +16,8 @@
         single_branch: true
 
     - name: Run TPM install_plugins
+      environment:
+        HOME: "{{ devbox_user_home }}"
       command:
         cmd: "{{ tpm_path }}/bin/install_plugins"
         creates: "{{ tpm_path }}/plugins"

--- a/box/ansible/roles/devbox/tasks/setup_tmux.yaml
+++ b/box/ansible/roles/devbox/tasks/setup_tmux.yaml
@@ -17,6 +17,7 @@
 
     - name: Run TPM install_plugins
       environment:
+        # needed to point TPM to install plugins in the devbox users home dir not root
         HOME: "{{ devbox_user_home }}"
       command:
         cmd: "{{ tpm_path }}/bin/install_plugins"

--- a/box/ansible/roles/devbox/tasks/tooling/install.yaml
+++ b/box/ansible/roles/devbox/tasks/tooling/install.yaml
@@ -47,6 +47,10 @@
     # postgresql tools
     - "pgcli={{ devbox_pgcli_version }}"
 
+- name: Install Python client for plugins
+  pip:
+    name: "pynvim=={{ devbox_nvim_pynvim_version }}"
+
 - name: Install FZF
   vars:
     fzf_version: "{{ devbox_fzf_version }}"


### PR DESCRIPTION
# Purpose
Attempting to use `tmux-fingers` within a newly deployed WARP box does not work.

Upon further investigation it was discovered that the plugin was install, just in the wrong home directory  (`root` instead of Devbox user).

# Contents
Fix Tmux Plugins not installing in Devbox User Home Dir:
- point TPM to correct home directory by setting `HOME` environment variable.
- remove `TMUX_PLUGIN_MANAGER_PATH` environment variableas its [not used by TPM](https://github.com/tmux-plugins/tpm/blob/b699a7e01c253ffb7818b02d62bce24190ec1019/scripts/helpers/plugin_functions.sh#L11) to determine install path