### PR TITLE
revert: "chore(deps): update dependency hashicorp/packer to v1.8.3 (#43)"

### DIFF
--- a/.github/workflows/box.yaml
+++ b/.github/workflows/box.yaml
@@ -12,8 +12,7 @@ on:
       - makefile
       - requirements.txt
 env:
-  # renovate: datasource=github-releases depName=hashicorp/packer versioning=hashicorp stripV
-  PACKER_VERSION: 1.8.3
+  PACKER_VERSION: 1.8.0
   # make ansible output human readable logs
   ANSIBLE_STDOUT_CALLBACK: debug
 jobs:

--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -74,7 +74,7 @@ devbox_hashicorp_terraform_version: 1.2.2
 # renovate: datasource=github-releases depName=hashicorp/terraform-ls versioning=hashicorp stripV
 devbox_hashicorp_terraform_langserver_version: 0.29.1
 # renovate: datasource=github-releases depName=hashicorp/packer versioning=hashicorp stripV
-devbox_hashicorp_packer_version: 1.8.3
+devbox_hashicorp_packer_version: 1.8.0
 
 # renovate: datasource=github-releases depName=junegunn/fzf
 devbox_fzf_version: 0.33.0


### PR DESCRIPTION
This reverts #43 as `1.8.3` has yet to be released on Hashicorp's APT repository.