### PR TITLE
perf(ansible): Reduce WARP Box CPU & Storage requirements

### DIFF
--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -9,9 +9,6 @@ devbox_user_home: /home/mrzzy
 # git revision of dotfiles to install
 devbox_dotfiles_rev: 79bc162f7778d3c35ccbd55ee7c4babda9c99639
 
-# whether to optimize deployment for a small storage footprint
-devbox_minimize_storage: true
-
 # system tools
 # needed for add-apt-repository
 # renovate: datasource=repology depName=ubuntu_20_04/software-properties
@@ -113,3 +110,9 @@ devbox_pgcli_version: 2.2.0-4
 devbox_kubectl_version: v1.25.1
 # renovate: datasource=github-releases depName=helm/helm stripV
 devbox_helm_version: 3.9.4
+
+# Optimizations
+# whether to optimize deployment for a small storage footprint
+devbox_minimize_storage: true
+# disable auto unattended upgrades
+devbox_uninstall_unattended_upgrades: true

--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -10,7 +10,7 @@ devbox_user_home: /home/mrzzy
 devbox_dotfiles_rev: 79bc162f7778d3c35ccbd55ee7c4babda9c99639
 
 # whether to optimize deployment for a small storage footprint
-devbox_minimize_storage: false
+devbox_minimize_storage: true
 
 # system tools
 # needed for add-apt-repository

--- a/box/ansible/roles/devbox/tasks/main.yaml
+++ b/box/ansible/roles/devbox/tasks/main.yaml
@@ -69,14 +69,6 @@
   become: true
   import_tasks: setup_users.yaml
 
-# Minimize Storage Footprint
-- name: Clear APT cache of package files & lists
-  become: true
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_fileglob:
-    - "/var/lib/apt/lists/*"
-    - "/var/cache/apt/archives/*.deb"
-    - "/var/cache/apt/archives/partial/*"
-  when: devbox_minimize_storage
+# Optimizations
+- name: Optimize Storage Footprint & Performance
+  import_tasks: optimize.yaml

--- a/box/ansible/roles/devbox/tasks/optimize.yaml
+++ b/box/ansible/roles/devbox/tasks/optimize.yaml
@@ -1,0 +1,25 @@
+#
+# WARP
+# Devbox Ansible Role
+# Optimizations
+#
+
+# minimize storage footprint
+- name: Clear APT cache of package files & lists
+  become: true
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "/var/lib/apt/lists/*"
+    - "/var/cache/apt/archives/*.deb"
+    - "/var/cache/apt/archives/partial/*"
+  when: devbox_minimize_storage
+
+# disable auto upgrades: upgrades hog the cpu at runtime
+- name: Disable Auto Upgrades by removing Unattended-upgrades
+  become: true
+  apt:
+    name: unattended-upgrades
+    state: absent
+  when: devbox_uninstall_unattended_upgrades


### PR DESCRIPTION
# Purpose
WARP VM was experiencing some performance issues running on small machine types with >1 vCPU core (eg. `e2-small` on GCP).

# Content
Reduce WARP Box CPU & Storage requirements:
- CPU: remove `unattended-upgrades` as automatic upgrades hog the CPU.
- Storage: enable storage optimizations by default (eg. APT package lists).
