### PR TITLE
feat(deploy): Migrate Terraform Module to Deploy WARP VM on GCE

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,11 @@ jobs:
       with:
         fetch-depth: "0"
 
+    - name: Setup Terraform CLI
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.3.1
+
     - name: Install Packer
       uses: hashicorp-contrib/setup-packer@v2
       with:
@@ -27,7 +32,7 @@ jobs:
         pre-commit install-hooks
 
     - name: Install Ansible Roles dependencies from Ansible Galaxy
-      run: ansible-galaxy install -r box/ansible/requirements.yaml
+      run: make ansible-deps
 
     - name: Flag Secrets
       uses: zricethezav/gitleaks-action@v1.6.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,8 +6,6 @@
 
 name: CI Pipeline
 on: push
-env:
-  PACKER_VERSION: 1.8.0
 jobs:
   lint:
     runs-on: ubuntu-20.04
@@ -20,7 +18,7 @@ jobs:
     - name: Install Packer
       uses: hashicorp-contrib/setup-packer@v2
       with:
-        packer-version: ${{ env.PACKER_VERSION }}
+        packer-version: 1.8.0
 
     - name: Install Python Tooling
       run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,11 +18,13 @@ jobs:
     - name: Setup Terraform CLI
       uses: hashicorp/setup-terraform@v2
       with:
+        # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
         terraform_version: 1.3.1
 
     - name: Install Packer
       uses: hashicorp-contrib/setup-packer@v2
       with:
+        # renovate: datasource=github-releases depName=hashicorp/packer versioning=hashicorp
         packer-version: 1.8.0
 
     - name: Install Python Tooling

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ build/
 venv/
 # vagrant
 .vagrant/
-
+# terraform
+.terraform/
 # tag files
 /tags
 /tags.*
 
 # vim-projectionist
 /.projections.json
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
   hooks:
   - id: terraform_fmt
     args:
-      - --args=-recursive -no-color
+      - --args=-chdir=deploy/terraform/gcp_vm -recursive -no-color
   - id: terraform_validate
     args:
-      - --args=-no-color
+      - --args=-chdir=deploy/terraform/gcp_vm -no-color -color

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,12 @@ repos:
   - id: check-github-workflows
 
 # lint terraform
-- repo: https://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform.git
   rev: v1.72.1
   hooks:
   - id: terraform_fmt
     args:
-      - --args=-chdir=deploy/terraform/gcp_vm -recursive -no-color
+      - --args=-recursive -no-color
   - id: terraform_validate
     args:
-      - --args=-chdir=deploy/terraform/gcp_vm -no-color -color
+      - --args=-no-color

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+  - id: check-merge-conflict
   - id: mixed-line-ending
     args: ["-f", "lf"]
 
@@ -42,3 +43,14 @@ repos:
   rev: 0.13.0
   hooks:
   - id: check-github-workflows
+
+# lint terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.72.1
+  hooks:
+  - id: terraform_fmt
+    args:
+      - --args=-recursive -no-color
+  - id: terraform_validate
+    args:
+      - --args=-no-color

--- a/deploy/terraform/gcp_vm/.terraform.lock.hcl
+++ b/deploy/terraform/gcp_vm/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.35.0"
+  constraints = ">= 4.22.0"
+  hashes = [
+    "h1:ybilPdQgRamexNcj8YpH74jIVGqiBIGaMULs3wx249g=",
+    "zh:122318ed6ba4253fca3fd0f75462c58337f1d86c34f20f2918e3fd12b2f0a31c",
+    "zh:15eb57c0c54002d04610c7682393407b23fde732993bf023536ff33a7c43212d",
+    "zh:29f7833338f778c1bf68d663a22c38ff92d642bf05a001005c570be7f55b6fae",
+    "zh:4f61d7cc0b02ae9e456b5547fe617c880a6396727ef9126c6ec60fab2ee6cc9e",
+    "zh:6b84cc5b571e453afc604899748954677211ad7d97c1eda0ac0ca27764169f7f",
+    "zh:7171bab4ac33a7852e8a7813d0742f5772666d132f8688507ecca209b19f5b3e",
+    "zh:802ba225215490587cdffe25dd180c7af9f0ba8cca9cbb0d8b31612cb0a594b4",
+    "zh:af6aee1833ba6a0dce980fd2b61183496e2c3ae030bb6350bd6e8a3b033fe291",
+    "zh:d146ef63698b53bf9dd22313250f1eab196c2f0aa84c3a4dce5a70b73c55a363",
+    "zh:dd4d00ec04d119c33ec63ab3f422a52404cefa9c8075ccc177949d119ceae16f",
+    "zh:e93cefc27b2ec7af10f35abc9e7c9fc6163af8f9dd2e028719b7280497113605",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/terraform/gcp_vm/main.tf
+++ b/deploy/terraform/gcp_vm/main.tf
@@ -1,0 +1,97 @@
+#
+# WARP
+# Terraform Deployment: WARP VM on GCP
+#
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.22.0"
+    }
+  }
+}
+
+locals {
+  warp_disk_id = "warp-disk"
+}
+
+data "google_compute_image" "warp_box" {
+  name = var.image
+}
+
+data "google_compute_network" "sandbox" {
+  name = "sandbox"
+}
+
+# service account for VM instance - needed to restrict IAM permissions on WARP VM
+# as the default service account gives GCP project wide editor permissions.
+resource "google_service_account" "warp" {
+  account_id   = "warp-vm"
+  display_name = "Service account for WARP VM instance(s)."
+}
+
+# disk for persistent storage when using the ephemeral development VM
+resource "google_compute_disk" "warp_disk" {
+  name = "warp-box-disk"
+  size = var.disk_size_gb
+}
+
+# allocate a static IP for WARP VM as long as its enabled.
+resource "google_compute_address" "warp" {
+  count = var.enabled ? 1 : 0
+
+  name         = "warp-vm-ip"
+  description  = "Static IP for a WARP VM instance(s)."
+  network_tier = "STANDARD"
+}
+
+# development VM instance
+resource "google_compute_instance" "wrap_vm" {
+  count        = var.enabled ? 1 : 0
+  name         = "warp-box-vm"
+  machine_type = var.machine_type
+  tags         = var.tags
+
+  # allow WARP VM to be stopped to update attributes such as machine_type.
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.warp_box.self_link
+    }
+  }
+
+  attached_disk {
+    source = google_compute_disk.warp_disk.self_link
+    # accessible via /dev/disk/by-id/google- prefix
+    device_name = local.warp_disk_id
+  }
+
+  network_interface {
+    network = data.google_compute_network.sandbox.self_link
+    access_config {
+      network_tier = one(google_compute_address.warp).network_tier
+      nat_ip       = one(google_compute_address.warp).address
+    }
+  }
+
+  service_account {
+    email = google_service_account.warp.email
+    # access control is enforced at the IAM role level
+    # https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#using
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    # user data is used by cloud-init to provision the system
+    user-data = templatefile("${path.module}/templates/cloud_init.yaml", {
+      warp_disk_device = "/dev/disk/by-id/google-${local.warp_disk_id}"
+      mountpoint       = "/home/mrzzy/disk"
+      ttyd_cert_base64 = base64encode(var.web_tls_cert)
+      ttyd_key_base64  = base64encode(var.web_tls_key)
+    })
+    # VM retrieves authorized ssh keys from 'ssh-keys' metadata key.
+    ssh-keys = var.ssh_public_key
+  }
+}

--- a/deploy/terraform/gcp_vm/outputs.tf
+++ b/deploy/terraform/gcp_vm/outputs.tf
@@ -1,0 +1,12 @@
+#
+# WARP
+# Terraform Deployment: WARP VM on GCP
+# Output variables
+#
+
+output "external_ip" {
+  description = "Publicly accessible IP of the WARP VM."
+  value = (
+    length(google_compute_address.warp) == 0 ? null : one(google_compute_address.warp).address
+  )
+}

--- a/deploy/terraform/gcp_vm/templates/cloud_init.yaml
+++ b/deploy/terraform/gcp_vm/templates/cloud_init.yaml
@@ -1,0 +1,39 @@
+#cloud-config
+bootcmd:
+  # format warp's persisent disk with btrfs
+  # verify that no fs exists on device before formatting
+  - >-
+    test -z "$(blkid ${warp_disk_device})" &&
+      mkfs.btrfs -L warp_disk ${warp_disk_device}
+  # create mountpoint for warp's persisent disk
+  - mkdir -p ${mountpoint}
+
+write_files:
+# write TLS certificate & private key for the TTYD web terminal
+- path: /etc/ssl/certs/ttyd.pem
+  encoding: b64
+  content: "${ttyd_cert_base64}"
+  permissions: "0644"
+- path: /etc/ssl/private/ttyd.key
+  encoding: b64
+  owner: root:ssl-cert
+  content: "${ttyd_key_base64}"
+  permissions: "0640"
+# store user's xdg cache within warp's persistent disk to persist across reboots
+- path: /etc/zsh/zshenv
+  append: true
+  content: 'export XDG_CACHE_HOME="${mountpoint}/.cache"'
+
+mounts:
+  # fstab entry to mount warp disk
+  - ["${warp_disk_device}", "${mountpoint}", "btrfs", "defaults", "0", "2"]
+
+runcmd:
+  # create & mount btrfs subvolume to persist docker volumes in warp's persistent disk
+  - systemctl stop docker
+  - btrfs subvolume create ${mountpoint}/docker_volumes
+  - mount -t btrfs -o subvol=docker_volumes ${warp_disk_device} /var/lib/docker/volumes
+  - systemctl start docker
+
+  # ensure warp disk is writeable by making the mrzzy user owner
+  - chown -R mrzzy:mrzzy ${mountpoint}

--- a/deploy/terraform/gcp_vm/variables.tf
+++ b/deploy/terraform/gcp_vm/variables.tf
@@ -1,0 +1,56 @@
+#
+# WARP
+# Terraform Deployment: WARP VM on GCP
+# Input Variables
+#
+
+variable "enabled" {
+  type        = bool
+  description = "Whether to deploy the WARP development VM instance."
+  default     = true
+}
+
+variable "image" {
+  type        = string
+  description = "Name of the VM image used to boot WARP development VM"
+  default     = "warp-box"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "GCE machine type to use for WARP development VM"
+  default     = "e2-standard-2"
+}
+
+variable "disk_size_gb" {
+  type        = number
+  description = "Size of the disk used mounted on the WARP development VM for persistent storage"
+  default     = 10
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "List of GCE Metadata tags to add to the VM instance."
+}
+
+variable "web_tls_cert" {
+  type        = string
+  description = <<-EOF
+  Full chain TLS certificate used to verify WARP VM identity when connecting
+  via its Web Terminal. The certificate should be encoded in the PEM format.
+  EOF
+}
+
+variable "web_tls_key" {
+  type        = string
+  sensitive   = true
+  description = <<-EOF
+  Private key of the TLS certificate used by the WARP VM's Web Terminal.
+  The private key should be encoded in the PEM format.
+  EOF
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "Public SSH Key to authorize on WARP VM for access via SSH."
+}

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ ANSIBLE_DIR=$(BOX_DIR)/ansible
 BOX_NAME:=mrzzy/warp-box
 
 # phony build rules
-.PHONY: all box box-gcp box-linode clean fmt lint apply packer-init
+.PHONY: all box box-gcp box-linode clean fmt lint apply packer-init ansible-deps
 .DEFAULT: all
 
 all: box
@@ -39,8 +39,10 @@ fmt:
 clean: clean-box
 
 # apply the ansible devbox playbook to the local machine
-apply: $(ANSIBLE_DIR)
+ansible-deps:
 	$(GALAXY) install -r box/ansible/requirements.yaml
+
+apply: $(ANSIBLE_DIR) ansible-deps
 	$(PLAYBOOK) \
 		--inventory 127.0.0.1, \
 		--connection local \
@@ -51,13 +53,13 @@ apply: $(ANSIBLE_DIR)
 box: build/package.box
 
 # development build: build box on virtualbox only.
-build/package.box: $(PACKER_DIR) packer-init
+build/package.box: $(PACKER_DIR) packer-init ansible-deps
 	$(PACKER) build --only="vagrant.ubuntu" --force $<
 
-box-gcp: $(PACKER_DIR) packer-init
+box-gcp: $(PACKER_DIR) packer-init ansible-deps
 	$(PACKER) build --only="googlecompute.ubuntu" --force $<
 
-box-linode: $(PACKER_DIR) packer-init
+box-linode: $(PACKER_DIR) packer-init ansible-deps
 	$(PACKER) build --only="linode.ubuntu" --force $<
 
 packer-init: $(PACKER_DIR)

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ ANSIBLE_DIR=$(BOX_DIR)/ansible
 BOX_NAME:=mrzzy/warp-box
 
 # phony build rules
-.PHONY: all box box-gcp box-linode clean fmt lint apply packer-init ansible-deps
+.PHONY: all box box-gcp clean fmt lint apply packer-init ansible-deps
 .DEFAULT: all
 
 all: box
@@ -58,9 +58,6 @@ build/package.box: $(PACKER_DIR) packer-init ansible-deps
 
 box-gcp: $(PACKER_DIR) packer-init ansible-deps
 	$(PACKER) build --only="googlecompute.ubuntu" --force $<
-
-box-linode: $(PACKER_DIR) packer-init ansible-deps
-	$(PACKER) build --only="linode.ubuntu" --force $<
 
 packer-init: $(PACKER_DIR)
 	$(PACKER) init $<

--- a/makefile
+++ b/makefile
@@ -27,8 +27,7 @@ BOX_NAME:=mrzzy/warp-box
 
 all: box
 
-lint:
-	$(PACKER) init $(PACKER_DIR)
+lint: packer-init
 	$(PACKER) fmt -check $(PACKER_DIR)
 	$(PACKER) validate $(PACKER_DIR)
 	$(PRE_CMT) run

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
     {
       "fileMatch": ["roles\\/.*\\/defaults\\/.*\\.yaml$"],
       "matchStrings": [
-        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?<stripV> stripV)?\\s+\\w+_version: *(?<currentValue>\\S+)"
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?<stripV> stripV)?\\s+\\w+version: *(?<currentValue>\\S+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}",
       "extractVersionTemplate": "^{{#if stripV}}[vV](?<version>.*){{else}}.*{{/if}}$"


### PR DESCRIPTION
# Purpose
Currently, there is a Terraform module for deploying WARP VM on GCE VMs residing on [mrzzy/nimbus](https://github.com/mrzzy/nimbus). Consolidate WARP infrastructure in WARP repository to allow it be managed from one place.

# Contents
Migrate Terraform Module to Deploy WARP VM on GCE:
- Move terraform module from nimbus repository
- Update makefile, pre-commit hooks & CI to support the terraform module.