### PR TITLE
ci(sync-nimbus): Add Workflow to sync Terraform Module deployed on Nimbus

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@
 # Lint
 #
 
-name: CI Pipeline
+name: Lint WARP Source Code
 on: push
 jobs:
   lint:

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -5,17 +5,35 @@
 
 name: Sync Revision of WARP Terraform Module on Nimbus
 on:
-  push:
+  push: {}
     #branches: [main]
     #paths:
     #- "deploy/terraform/*"
 jobs:
   create-nimbus-pr:
-    name: Create PR to update WARP Terraform Module on Nimbus
+    name: Create Pull Request to update WARP Terraform Module on Nimbus
     runs-on: ubuntu-22.04
     steps:
       - name: Clone Nimbus repository
         uses: actions/checkout@v3
         with:
           repository: mrzzy/nimbus
-  # TODO(mrzzy): prevent duplicates
+      - name: Update revision of WARP Terraform Modules
+        run: |
+          sed -ie \
+            "/source.*=.*github.com\/mrzzy\/warp/s/ref=.*/ref=${{ github.sha }}/" \
+            terraform/gcp.tf
+      - name: Create Pull Request on Nimbus
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: "${{ secrets.GH_PUSH_TOKEN }}"
+          # Commit
+          committer: github-actions[bot]@users.noreply.github.com
+          author: github-actions[bot]@users.noreply.github.com
+          commit-message: "build(terraform): bump revision of warp vm TF module"
+          # Pull request
+          branch: build/update-warp-tf-module
+          title: "build(terraform): Update WARP VM Terraform module."
+          body: "Update revision of WARP VM Terraform module to \
+                 ${{ github.repository}}@${{ github.sha }}"
+          delete-branch: true

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Update revision of WARP Terraform Modules
         run: |
           sed -i -e \
-            "/source.*=.*github.com\/mrzzy\/warp/s/ref=.*/ref=${{ github.sha }}/" \
+            '/source.*=.*github.com\/mrzzy\/warp/s/ref=[^"]*/ref=${{ github.sha }}/' \
             terraform/gcp.tf
       - name: Create Pull Request on Nimbus
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -1,0 +1,21 @@
+#
+# WARP
+# Sync Terraform Module on Nimbus
+#
+
+name: Sync Revision of WARP Terraform Module on Nimbus
+on:
+  push:
+    #branches: [main]
+    #paths:
+    #- "deploy/terraform/*"
+jobs:
+  create-nimbus-pr:
+    name: Create PR to update WARP Terraform Module on Nimbus
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone Nimbus repository
+        uses: actions/checkout@v3
+        with:
+          repository: mrzzy/nimbus
+  # TODO(mrzzy): prevent duplicates

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -5,10 +5,10 @@
 
 name: Sync Revision of WARP Terraform Module on Nimbus
 on:
-  push: {}
-    #branches: [main]
-    #paths:
-    #- "deploy/terraform/*"
+  push:
+    branches: [main]
+    paths:
+    - "deploy/terraform/*"
 jobs:
   create-nimbus-pr:
     name: Create Pull Request to update WARP Terraform Module on Nimbus

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -20,7 +20,7 @@ jobs:
           repository: mrzzy/nimbus
       - name: Update revision of WARP Terraform Modules
         run: |
-          sed -ie \
+          sed -i -e \
             "/source.*=.*github.com\/mrzzy\/warp/s/ref=.*/ref=${{ github.sha }}/" \
             terraform/gcp.tf
       - name: Create Pull Request on Nimbus

--- a/.github/workflows/sync-nimbus.yaml
+++ b/.github/workflows/sync-nimbus.yaml
@@ -28,8 +28,6 @@ jobs:
         with:
           token: "${{ secrets.GH_PUSH_TOKEN }}"
           # Commit
-          committer: github-actions[bot]@users.noreply.github.com
-          author: github-actions[bot]@users.noreply.github.com
           commit-message: "build(terraform): bump revision of warp vm TF module"
           # Pull request
           branch: build/update-warp-tf-module

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
 
 # lint github actions workflows
 - repo: https://github.com/sirosen/check-jsonschema.git
-  rev: 0.13.0
+  rev: 0.18.3
   hooks:
   - id: check-github-workflows
 


### PR DESCRIPTION
# Purpose
Post #70, the Terraform module in [mrzzy/nimbus](https://github.com/mrzzy/nimbus) has to be kept manually in sync.
Automate way this manual chore.

# Contents
Add Github Actions Workflow `sync-nimbus` to sync Terraform Module deployed on Nimbus:
- when changes to the `gcp_vm` Terraform module is detected, this workflow will trigger will automatically create a pull request to update the Terraform module on [mrzzy/nimbus](https://github.com/mrzzy/nimbus).
- keeping [mrzzy/nimbus](https://github.com/mrzzy/nimbus) updated with the latest Terraform module will be reduced to merging a PR.