### PR TITLE
fix(renovate): Fix Renovate extract version regex & Repology dependency names

### DIFF
--- a/.github/workflows/box.yaml
+++ b/.github/workflows/box.yaml
@@ -79,6 +79,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: "/tmp/gcp_packer_key.json"
         KEY_BASE64: ${{ secrets.gcp_packer_key_base64 }}
         PKR_VAR_web_term_password: ${{ secrets.BOX_WEB_TERM_PASSWORD }}
+        PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       run: |
         # decode base64 & write key to disk
         echo "$KEY_BASE64" | base64 -d >$GOOGLE_APPLICATION_CREDENTIALS

--- a/box/ansible/roles/devbox/defaults/main.yaml
+++ b/box/ansible/roles/devbox/defaults/main.yaml
@@ -11,7 +11,7 @@ devbox_dotfiles_rev: 68ca35463fbb008dd3a784fd5f56c147c6a1f884
 
 # system tools
 # needed for add-apt-repository
-# renovate: datasource=repology depName=ubuntu_20_04/software-properties
+# renovate: datasource=repology depName=ubuntu_20_04/software-properties-common
 devbox_software_properties_version: 0.99.9.8
 # load iptables rules on boot
 # renovate: datasource=repology depName=ubuntu_20_04/iptables-persistent
@@ -20,8 +20,8 @@ devbox_iptables_persistent_version: 1.0.14ubuntu1
 # renovate: datasource=repology depName=ubuntu_20_04/acl
 devbox_acl_version: 2.2.53-6
 # ssh server
-# renovate: datasource=repology depName=ubuntu_20_04/openssh
-devbox_openssh_version: 1:8.2p1-4ubuntu0.5
+# renovate: datasource=repology depName=ubuntu_20_04/openssh-server
+devbox_openssh_server_version: 1:8.2p1-4ubuntu0.5
 
 # Neovim text editor
 # renovate: datasource=repology depName=ubuntu_20_04/neovim
@@ -34,7 +34,7 @@ devbox_nvim_pynvim_version: 0.4.3
 # Language-agnostic tools
 # renovate: datasource=repology depName=ubuntu_20_04/entr
 devbox_entr_version: 4.4-1
-# renovate: datasource=repology depName=ubuntu_20_04/rust-ripgrep
+# renovate: datasource=repology depName=ubuntu_20_04/ripgrep
 devbox_ripgrep_version: 11.0.2-1ubuntu0.1
 # renovate: datasource=repology depName=ubuntu_20_04/docker.io
 devbox_docker_version: 20.10.12-0ubuntu2~20.04.1
@@ -78,9 +78,9 @@ devbox_fzf_dir: /usr/local/share/fzf
 # python & tools
 # renovate: datasource=repology depName=ubuntu_20_04/python3.8
 devbox_python_version: 3.8.10-0ubuntu1~20.04.5
-# renovate: datasource=repology depName=ubuntu_20_04/python-pip
+# renovate: datasource=repology depName=ubuntu_20_04/python3-pip
 devbox_python_pip_version: 20.0.2-5ubuntu1.6
-# renovate: datasource=repology depName=ubuntu_20_04/wheel
+# renovate: datasource=repology depName=ubuntu_20_04/python-wheel-common
 devbox_python_wheel_version: 0.34.2-1
 
 # jvm languages & tools

--- a/box/ansible/roles/devbox/tasks/install_system.yaml
+++ b/box/ansible/roles/devbox/tasks/install_system.yaml
@@ -13,7 +13,7 @@
     - "software-properties-common={{ devbox_software_properties_version }}"
     - "iptables-persistent={{ devbox_iptables_persistent_version }}"
     - "acl={{ devbox_acl_version }}"
-    - "openssh-server={{ devbox_openssh_version }}"
+    - "openssh-server={{ devbox_openssh_server_version }}"
 
 - name: Install rclone via .deb package with APT
   become: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": [
-    "main",
-    "release/ubuntu-20.04",
-    "fix/renovate-detection"
+    "main"
   ],
   "extends": [
     "config:base",

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?<stripV> stripV)?\\s+\\w+version: *(?<currentValue>\\S+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}",
-      "extractVersionTemplate": "^{{#if stripV(?}}[vV](?<version>.*){{else}}(?<version>.*){{/if}}$"
+      "extractVersionTemplate": "^(?<version>{{#if stripV}}[vV]{{else}}{{/if}}.*)$"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?<stripV> stripV)?\\s+\\w+version: *(?<currentValue>\\S+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}",
-      "extractVersionTemplate": "^{{#if stripV}}[vV](?<version>.*){{else}}.*{{/if}}$"
+      "extractVersionTemplate": "^{{#if stripV(?}}[vV](?<version>.*){{else}}(?<version>.*){{/if}}$"
     }
   ]
 }


### PR DESCRIPTION
#  Purpose
Identified two issues with Renovate installation:
- Renovate `Found no results from datasource that look like a version` despite manual checking of the Github API endpoint showing that correct versions were returned.
- Some Repology datasource version queries were returning 404, package not found.

# Contents
Fix Renovate extract version regex:
- Prior regex missed `(?<version>..)` capturing group for `else` clause, leading to renovate to find "no" versions.
- Moved capturing group to surround if/else conditional to make this less error prone.  

Fix Repology dependency names:
- Repology uses Ubuntu repository package name, instead of the name listed Repology site.