### PR TITLE
build(box): Build WARP VM on Ubuntu 22.04 LTS

### DIFF
--- a/box/ansible/roles/c_cpp/defaults/main.yaml
+++ b/box/ansible/roles/c_cpp/defaults/main.yaml
@@ -6,5 +6,5 @@
 
 # c/c++ tools
 # renovate: datasource=repology depName=ubuntu_22_04/cmake
-devbox_c_cmake_version: 3.16.3-1ubuntu1
-devbox_c_clangd_version: "1:12.0.0-3ubuntu1~20.04.5"
+devbox_c_cmake_version: 3.22.1-1ubuntu1
+devbox_c_clangd_version: "1:14.0-55~exp2"

--- a/box/ansible/roles/c_cpp/defaults/main.yaml
+++ b/box/ansible/roles/c_cpp/defaults/main.yaml
@@ -5,6 +5,6 @@
 #
 
 # c/c++ tools
-# renovate: datasource=repology depName=ubuntu_20_04/cmake
+# renovate: datasource=repology depName=ubuntu_22_04/cmake
 devbox_c_cmake_version: 3.16.3-1ubuntu1
 devbox_c_clangd_version: "1:12.0.0-3ubuntu1~20.04.5"

--- a/box/ansible/roles/c_cpp/defaults/main.yaml
+++ b/box/ansible/roles/c_cpp/defaults/main.yaml
@@ -6,5 +6,5 @@
 
 # c/c++ tools
 # renovate: datasource=repology depName=ubuntu_22_04/cmake
-devbox_c_cmake_version: 3.22.1-1ubuntu1
+devbox_c_cmake_version: 3.22.1-1ubuntu1.22.04.1
 devbox_c_clangd_version: "1:14.0-55~exp2"

--- a/box/ansible/roles/c_cpp/tasks/main.yaml
+++ b/box/ansible/roles/c_cpp/tasks/main.yaml
@@ -11,4 +11,4 @@
     state: present
   loop:
     - "cmake={{ devbox_c_cmake_version }}"
-    - "clangd-12={{ devbox_c_clangd_version }}"
+    - "clangd={{ devbox_c_clangd_version }}"

--- a/box/ansible/roles/cloud/defaults/main.yaml
+++ b/box/ansible/roles/cloud/defaults/main.yaml
@@ -17,6 +17,6 @@ devbox_hashicorp_virtualbox_version: 6.1.32-dfsg-1build1
 # renovate: datasource=github-releases depName=infracost/infracost
 devbox_infracost_version: v0.10.13
 # renovate: datasource=pypi depName=ansible-base
-devbox_ansible_version: 6.5.0
+devbox_ansible_version: 2.10.17
 # renovate: datasource=pypi depName=linode-cli versioning=python
 devbox_linode_cli_version: 5.23.0

--- a/box/ansible/roles/cloud/defaults/main.yaml
+++ b/box/ansible/roles/cloud/defaults/main.yaml
@@ -12,8 +12,8 @@ devbox_hashicorp_terraform_langserver_version: 0.29.3
 devbox_hashicorp_packer_version: 1.8.3-1
 # renovate: datasource=github-releases depName=hashicorp/vagrant versioning=hashicorp stripV
 devbox_hashicorp_vagrant_version: 2.3.2
-# renovate: datasource=repology depname=ubuntu_20_04/virtualbox
-devbox_hashicorp_virtualbox_version: 6.1.16-dfsg-6~ubuntu1.20.04.2
+# renovate: datasource=repology depname=ubuntu_22_04/virtualbox
+devbox_hashicorp_virtualbox_version: 6.1.32-dfsg-1build1
 # renovate: datasource=github-releases depName=infracost/infracost
 devbox_infracost_version: v0.10.13
 # renovate: datasource=pypi depName=ansible-base

--- a/box/ansible/roles/cloud/defaults/main.yaml
+++ b/box/ansible/roles/cloud/defaults/main.yaml
@@ -16,7 +16,7 @@ devbox_hashicorp_vagrant_version: 2.3.2
 devbox_hashicorp_virtualbox_version: 6.1.16-dfsg-6~ubuntu1.20.04.2
 # renovate: datasource=github-releases depName=infracost/infracost
 devbox_infracost_version: v0.10.13
-# renovate: datasource=repology depName=ubuntu_22_04/ansible
-devbox_ansible_version: 5.10.0-1ppa~focal
+# renovate: datasource=pypi depName=ansible-base
+devbox_ansible_version: 6.5.0
 # renovate: datasource=pypi depName=linode-cli versioning=python
 devbox_linode_cli_version: 5.23.0

--- a/box/ansible/roles/cloud/defaults/main.yaml
+++ b/box/ansible/roles/cloud/defaults/main.yaml
@@ -16,7 +16,7 @@ devbox_hashicorp_vagrant_version: 2.3.2
 devbox_hashicorp_virtualbox_version: 6.1.16-dfsg-6~ubuntu1.20.04.2
 # renovate: datasource=github-releases depName=infracost/infracost
 devbox_infracost_version: v0.10.13
-# renovate: datasource=repology depName=ubuntu_20_04/ansible
+# renovate: datasource=repology depName=ubuntu_22_04/ansible
 devbox_ansible_version: 5.10.0-1ppa~focal
 # renovate: datasource=pypi depName=linode-cli versioning=python
 devbox_linode_cli_version: 5.23.0

--- a/box/ansible/roles/cloud/tasks/main.yaml
+++ b/box/ansible/roles/cloud/tasks/main.yaml
@@ -22,12 +22,6 @@
     repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
     state: present
 
-- name: Register Ansible APT PPA
-  become: true
-  apt_repository:
-    repo: "ppa:ansible/ansible"
-    state: present
-
 - name: Install Cloud tools with APT
   become: true
   apt:
@@ -39,7 +33,6 @@
     - "terraform-ls={{ devbox_hashicorp_terraform_langserver_version }}"
     - "vagrant={{ devbox_hashicorp_vagrant_version }}"
     - "virtualbox={{ devbox_hashicorp_virtualbox_version }}"
-    - "ansible={{ devbox_ansible_version }}"
 
 - name: Install Cloud tools with Pip
   become: true
@@ -48,6 +41,7 @@
     state: present
   loop:
     - "linode-cli=={{ devbox_linode_cli_version }}"
+    - "ansible-base=={{ devbox_ansible_version }}"
 
 # Install Infracost
 - name: Install Infracost

--- a/box/ansible/roles/docker/defaults/main.yaml
+++ b/box/ansible/roles/docker/defaults/main.yaml
@@ -4,7 +4,7 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_20_04/docker.io
+# renovate: datasource=repology depName=ubuntu_22_04/docker.io
 devbox_docker_version: 20.10.12-0ubuntu2~20.04.1
 # renovate: datasource=github-releases depName=docker/compose
 devbox_docker_compose_version: v2.12.2

--- a/box/ansible/roles/docker/defaults/main.yaml
+++ b/box/ansible/roles/docker/defaults/main.yaml
@@ -5,6 +5,6 @@
 #
 
 # renovate: datasource=repology depName=ubuntu_22_04/docker.io
-devbox_docker_version: 20.10.12-0ubuntu2~20.04.1
+devbox_docker_version: 20.10.12-0ubuntu4
 # renovate: datasource=github-releases depName=docker/compose
 devbox_docker_compose_version: v2.12.2

--- a/box/ansible/roles/neovim/defaults/main.yaml
+++ b/box/ansible/roles/neovim/defaults/main.yaml
@@ -8,7 +8,7 @@ devbox_user: mrzzy
 devbox_user_home: /home/mrzzy
 
 # Neovim text editor
-# renovate: datasource=repology depName=ubuntu_20_04/neovim
+# renovate: datasource=repology depName=ubuntu_22_04/neovim
 devbox_nvim_version: 0.4.3-3
 # renovate: datasource=github-releases depName=junegunn/vim-plug
 devbox_nvim_vim_plug_version: 0.11.0

--- a/box/ansible/roles/neovim/defaults/main.yaml
+++ b/box/ansible/roles/neovim/defaults/main.yaml
@@ -9,6 +9,6 @@ devbox_user_home: /home/mrzzy
 
 # Neovim text editor
 # renovate: datasource=repology depName=ubuntu_22_04/neovim
-devbox_nvim_version: 0.4.3-3
+devbox_nvim_version: 0.6.1-3
 # renovate: datasource=github-releases depName=junegunn/vim-plug
 devbox_nvim_vim_plug_version: 0.11.0

--- a/box/ansible/roles/openssh/defaults/main.yaml
+++ b/box/ansible/roles/openssh/defaults/main.yaml
@@ -4,7 +4,7 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_20_04/openssh
+# renovate: datasource=repology depName=ubuntu_22_04/openssh
 devbox_openssh_server_version: 1:8.2p1-4ubuntu0.5
 # niceness level of high priority processes (ie. ssh)
 devbox_priority_nice_level: -2

--- a/box/ansible/roles/openssh/defaults/main.yaml
+++ b/box/ansible/roles/openssh/defaults/main.yaml
@@ -5,6 +5,6 @@
 #
 
 # renovate: datasource=repology depName=ubuntu_22_04/openssh
-devbox_openssh_server_version: 1:8.2p1-4ubuntu0.5
+devbox_openssh_server_version: 1:8.9p1-3
 # niceness level of high priority processes (ie. ssh)
 devbox_priority_nice_level: -2

--- a/box/ansible/roles/postgres/defaults/main.yaml
+++ b/box/ansible/roles/postgres/defaults/main.yaml
@@ -5,4 +5,4 @@
 #
 
 # renovate: datasource=repology depName=ubuntu_22_04/pgcli
-devbox_pgcli_version: 2.2.0-4
+devbox_pgcli_version: 3.3.1-1

--- a/box/ansible/roles/postgres/defaults/main.yaml
+++ b/box/ansible/roles/postgres/defaults/main.yaml
@@ -4,5 +4,5 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_20_04/pgcli
+# renovate: datasource=repology depName=ubuntu_22_04/pgcli
 devbox_pgcli_version: 2.2.0-4

--- a/box/ansible/roles/python/defaults/main.yaml
+++ b/box/ansible/roles/python/defaults/main.yaml
@@ -5,11 +5,11 @@
 #
 
 # renovate: datasource=repology depName=ubuntu_22_04/python
-devbox_python_version: 3.10.4-0ubuntu2
+devbox_python_version: 3.10.6-1~22.04
 # renovate: datasource=repology depName=ubuntu_22_04/python-pip
-devbox_python_pip_version: 20.0.2-5ubuntu1.6
-# renovate: datasource=repology depName=ubuntu_22_04/python-wheel-common
-devbox_python_wheel_version: 0.34.2-1
+devbox_python_pip_version: 22.0.2+dfsg-1
+# renovate: datasource=repology depName=ubuntu_22_04/wheel
+devbox_python_wheel_version: 0.37.1-2
 
 # renovate: datasource=pypi depName=pynvim versioning=python
 devbox_python_pynvim_version: 0.4.3

--- a/box/ansible/roles/python/defaults/main.yaml
+++ b/box/ansible/roles/python/defaults/main.yaml
@@ -4,8 +4,8 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_22_04/python3.8
-devbox_python_version: 3.8.10-0ubuntu1~20.04.5
+# renovate: datasource=repology depName=ubuntu_22_04/python
+devbox_python_version: 3.10.4-0ubuntu2
 # renovate: datasource=repology depName=ubuntu_22_04/python-pip
 devbox_python_pip_version: 20.0.2-5ubuntu1.6
 # renovate: datasource=repology depName=ubuntu_22_04/python-wheel-common

--- a/box/ansible/roles/python/defaults/main.yaml
+++ b/box/ansible/roles/python/defaults/main.yaml
@@ -4,11 +4,11 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_20_04/python3.8
+# renovate: datasource=repology depName=ubuntu_22_04/python3.8
 devbox_python_version: 3.8.10-0ubuntu1~20.04.5
-# renovate: datasource=repology depName=ubuntu_20_04/python-pip
+# renovate: datasource=repology depName=ubuntu_22_04/python-pip
 devbox_python_pip_version: 20.0.2-5ubuntu1.6
-# renovate: datasource=repology depName=ubuntu_20_04/python-wheel-common
+# renovate: datasource=repology depName=ubuntu_22_04/python-wheel-common
 devbox_python_wheel_version: 0.34.2-1
 
 # renovate: datasource=pypi depName=pynvim versioning=python

--- a/box/ansible/roles/python/tasks/main.yaml
+++ b/box/ansible/roles/python/tasks/main.yaml
@@ -11,8 +11,8 @@
     state: present
   loop:
     # python & tools
-    - "python3.8={{ devbox_python_version }}"
-    - "python3.8-venv={{ devbox_python_version }}"
+    - "python3={{ devbox_python_version }}"
+    - "python3-venv={{ devbox_python_version }}"
     - "python3-pip={{ devbox_python_pip_version }}"
     - "python-wheel-common={{ devbox_python_wheel_version }}"
 

--- a/box/ansible/roles/python/tasks/main.yaml
+++ b/box/ansible/roles/python/tasks/main.yaml
@@ -14,7 +14,7 @@
     - "python3={{ devbox_python_version }}"
     - "python3-venv={{ devbox_python_version }}"
     - "python3-pip={{ devbox_python_pip_version }}"
-    - "python-wheel-common={{ devbox_python_wheel_version }}"
+    - "python3-wheel={{ devbox_python_wheel_version }}"
 
 - name: Install Neovim client for Python with Pip
   become: true

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -6,7 +6,7 @@
 
 # needed for add-apt-repository
 # renovate: datasource=repology depName=ubuntu_22_04/software-properties
-devbox_software_properties_version: 0.99.9.8
+devbox_software_properties_version: 0.99.22.3
 # needed for ansible to become a unprivilleged user
 # renovate: datasource=repology depName=ubuntu_22_04/acl
 devbox_acl_version: 2.2.53-6

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -5,11 +5,11 @@
 #
 
 # needed for add-apt-repository
-# renovate: datasource=repology depName=ubuntu_20_04/software-properties
+# renovate: datasource=repology depName=ubuntu_22_04/software-properties
 devbox_software_properties_version: 0.99.9.8
 # needed for ansible to become a unprivilleged user
-# renovate: datasource=repology depName=ubuntu_20_04/acl
+# renovate: datasource=repology depName=ubuntu_22_04/acl
 devbox_acl_version: 2.2.53-6
 # needed for ansible's git module
-# renovate: datasource=repology depName=ubuntu_20_04/git
+# renovate: datasource=repology depName=ubuntu_22_04/git
 devbox_git_version: "1:2.25.1-1ubuntu3.6"

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -12,4 +12,4 @@ devbox_software_properties_version: 0.99.22.3
 devbox_acl_version: 2.3.1-1
 # needed for ansible's git module
 # renovate: datasource=repology depName=ubuntu_22_04/git
-devbox_git_version: "1:2.25.1-1ubuntu3.6"
+devbox_git_version: "1:2.34.1-1ubuntu1.5"

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -9,7 +9,7 @@
 devbox_software_properties_version: 0.99.22.3
 # needed for ansible to become a unprivilleged user
 # renovate: datasource=repology depName=ubuntu_22_04/acl
-devbox_acl_version: 2.2.53-6
+devbox_acl_version: 2.3.1-1
 # needed for ansible's git module
 # renovate: datasource=repology depName=ubuntu_22_04/git
 devbox_git_version: "1:2.25.1-1ubuntu3.6"

--- a/box/ansible/roles/tmux/defaults/main.yaml
+++ b/box/ansible/roles/tmux/defaults/main.yaml
@@ -10,4 +10,4 @@ devbox_user_home: /home/mrzzy
 # renovate: datasource=repology depName=ubuntu_22_04/tmux
 devbox_tmux_version: 3.0a-2ubuntu0.3
 # renovate: datasource=repology depName=ubuntu_22_04/gawk
-devbox_tmux_gawk_version: 1:5.0.1+dfsg-1
+devbox_tmux_gawk_version: 1:5.1.0-1build3

--- a/box/ansible/roles/tmux/defaults/main.yaml
+++ b/box/ansible/roles/tmux/defaults/main.yaml
@@ -7,7 +7,7 @@
 devbox_user: mrzzy
 devbox_user_home: /home/mrzzy
 
-# renovate: datasource=repology depName=ubuntu_20_04/tmux
+# renovate: datasource=repology depName=ubuntu_22_04/tmux
 devbox_tmux_version: 3.0a-2ubuntu0.3
-# renovate: datasource=repology depName=ubuntu_20_04/gawk
+# renovate: datasource=repology depName=ubuntu_22_04/gawk
 devbox_tmux_gawk_version: 1:5.0.1+dfsg-1

--- a/box/ansible/roles/tmux/defaults/main.yaml
+++ b/box/ansible/roles/tmux/defaults/main.yaml
@@ -8,6 +8,6 @@ devbox_user: mrzzy
 devbox_user_home: /home/mrzzy
 
 # renovate: datasource=repology depName=ubuntu_22_04/tmux
-devbox_tmux_version: 3.0a-2ubuntu0.3
+devbox_tmux_version: 3.2a-4build1
 # renovate: datasource=repology depName=ubuntu_22_04/gawk
 devbox_tmux_gawk_version: 1:5.1.0-1build3

--- a/box/ansible/roles/tools/defaults/main.yaml
+++ b/box/ansible/roles/tools/defaults/main.yaml
@@ -9,16 +9,16 @@ devbox_pre_commit_version: 2.20.0
 # renovate: datasource=npm depName=@bitwarden/cli versioning=npm
 devbox_bw_version: 2022.10.0
 # renovate: datasource=repology depName=ubuntu_22_04/entr
-devbox_entr_version: 4.4-1
+devbox_entr_version: 5.1-1
 # renovate: datasource=repology depName=ubuntu_22_04/rust-ripgrep
-devbox_ripgrep_version: 11.0.2-1ubuntu0.1
+devbox_ripgrep_version: 13.0.0-2ubuntu0.1
 # renovate: datasource=repology depName=ubuntu_22_04/ranger
-devbox_ranger_version: 1.9.3-1build1
+devbox_ranger_version: 1.9.3-3ubuntu1
 # renovate: datasource=repology depName=ubuntu_22_04/universal-ctags
-devbox_universal_ctags_version: 0+git20181215-2
+devbox_universal_ctags_version: 5.9.20210829.0-1
 # renovate: datasource=repology depName=ubuntu_22_04/jq
-devbox_jq_version: 1.6-1ubuntu0.20.04.1
+devbox_jq_version: 1.6-2.1ubuntu3
 # renovate: datasource=github-releases depName=mikefarah/yq
 devbox_yq_version: v4.29.2
 # renovate: datasource=repology depName=ubuntu_22_04/bind9
-devbox_dnsutils_version: 1:9.16.1-0ubuntu2.11
+devbox_dnsutils_version: 1:9.18.1-1ubuntu1.2

--- a/box/ansible/roles/tools/defaults/main.yaml
+++ b/box/ansible/roles/tools/defaults/main.yaml
@@ -8,17 +8,17 @@
 devbox_pre_commit_version: 2.20.0
 # renovate: datasource=npm depName=@bitwarden/cli versioning=npm
 devbox_bw_version: 2022.10.0
-# renovate: datasource=repology depName=ubuntu_20_04/entr
+# renovate: datasource=repology depName=ubuntu_22_04/entr
 devbox_entr_version: 4.4-1
-# renovate: datasource=repology depName=ubuntu_20_04/rust-ripgrep
+# renovate: datasource=repology depName=ubuntu_22_04/rust-ripgrep
 devbox_ripgrep_version: 11.0.2-1ubuntu0.1
-# renovate: datasource=repology depName=ubuntu_20_04/ranger
+# renovate: datasource=repology depName=ubuntu_22_04/ranger
 devbox_ranger_version: 1.9.3-1build1
-# renovate: datasource=repology depName=ubuntu_20_04/universal-ctags
+# renovate: datasource=repology depName=ubuntu_22_04/universal-ctags
 devbox_universal_ctags_version: 0+git20181215-2
-# renovate: datasource=repology depName=ubuntu_20_04/jq
+# renovate: datasource=repology depName=ubuntu_22_04/jq
 devbox_jq_version: 1.6-1ubuntu0.20.04.1
 # renovate: datasource=github-releases depName=mikefarah/yq
 devbox_yq_version: v4.29.2
-# renovate: datasource=repology depName=ubuntu_20_04/bind9
+# renovate: datasource=repology depName=ubuntu_22_04/bind9
 devbox_dnsutils_version: 1:9.16.1-0ubuntu2.11

--- a/box/ansible/roles/ttyd/defaults/main.yaml
+++ b/box/ansible/roles/ttyd/defaults/main.yaml
@@ -19,5 +19,5 @@ devbox_ttyd_https_port: 7681
 devbox_ttyd_nice_level: -2
 
 # install iptables persistent needed to config iptables rules for TTYD
-# renovate: datasource=repology depName=ubuntu_20_04/iptables-persistent
+# renovate: datasource=repology depName=ubuntu_22_04/iptables-persistent
 devbox_iptables_persistent_version: 1.0.14ubuntu1

--- a/box/ansible/roles/ttyd/defaults/main.yaml
+++ b/box/ansible/roles/ttyd/defaults/main.yaml
@@ -20,4 +20,4 @@ devbox_ttyd_nice_level: -2
 
 # install iptables persistent needed to config iptables rules for TTYD
 # renovate: datasource=repology depName=ubuntu_22_04/iptables-persistent
-devbox_iptables_persistent_version: 1.0.14ubuntu1
+devbox_iptables_persistent_version: 1.0.16

--- a/box/ansible/roles/zsh/defaults/main.yaml
+++ b/box/ansible/roles/zsh/defaults/main.yaml
@@ -4,9 +4,9 @@
 # Default Variables
 #
 
-# renovate: datasource=repology depName=ubuntu_20_04/zsh
+# renovate: datasource=repology depName=ubuntu_22_04/zsh
 devbox_zsh_version: 5.8-3ubuntu1.1
-# renovate: datasource=repology depName=ubuntu_20_04/zsh-autosuggestions
+# renovate: datasource=repology depName=ubuntu_22_04/zsh-autosuggestions
 devbox_zsh_autosuggest_version: 0.6.4-1
-# renovate: datasource=repology depName=ubuntu_20_04/zsh-syntax-highlighting
+# renovate: datasource=repology depName=ubuntu_22_04/zsh-syntax-highlighting
 devbox_zsh_syntax_version: 0.6.0-3

--- a/box/ansible/roles/zsh/defaults/main.yaml
+++ b/box/ansible/roles/zsh/defaults/main.yaml
@@ -5,8 +5,8 @@
 #
 
 # renovate: datasource=repology depName=ubuntu_22_04/zsh
-devbox_zsh_version: 5.8-3ubuntu1.1
+devbox_zsh_version: 5.8.1-1
 # renovate: datasource=repology depName=ubuntu_22_04/zsh-autosuggestions
-devbox_zsh_autosuggest_version: 0.6.4-1
+devbox_zsh_autosuggest_version: 0.7.0-1
 # renovate: datasource=repology depName=ubuntu_22_04/zsh-syntax-highlighting
-devbox_zsh_syntax_version: 0.6.0-3
+devbox_zsh_syntax_version: 0.7.1-2

--- a/box/packer/sources.pkr.hcl
+++ b/box/packer/sources.pkr.hcl
@@ -27,8 +27,8 @@ source "googlecompute" "ubuntu" {
   preemptible = true
 
   # compute engine image as build base
-  source_image_family = "ubuntu-minimal-2004-lts"
-  source_image        = "ubuntu-minimal-2004-focal-v20220419a"
+  source_image_family = "ubuntu-minimal-2204-lts"
+  source_image        = "ubuntu-minimal-2204-jammy-v20221101"
 
   # vm image name
   image_name = "warp-box${var.image_suffix}"

--- a/box/packer/sources.pkr.hcl
+++ b/box/packer/sources.pkr.hcl
@@ -9,8 +9,8 @@ source "vagrant" "ubuntu" {
   provider     = "virtualbox"
 
   # source box
-  source_path = "ubuntu/focal64"
-  box_version = "v20220215.1.0"
+  source_path = "ubuntu/jammy64"
+  box_version = "v20221101.1.0"
 
   # output box
   box_name   = "mrzzy/warp-box${var.image_suffix}"


### PR DESCRIPTION
# Purpose
Access newly software packages available in newer LTS's package repository.

# Contents
Build WARP VM on Ubuntu 22.04 LTS:
- bump package versions to versions available in 22.04's package repository.
- reference 22.04 repository in `# renovate:` comments.

Refactors:
- install Ansible with `pip` instead of `apt-get` as the former offers newer versions.
- Python & `clangd` no longer pegged to 3.8 & 12 versions respectively by package name.