### PR TITLE
build(ansible): Update dotfiles embedded in WARP Box

### DIFF
--- a/box/ansible/roles/dotfiles/defaults/main.yaml
+++ b/box/ansible/roles/dotfiles/defaults/main.yaml
@@ -8,4 +8,4 @@ devbox_user: mrzzy
 devbox_user_home: /home/mrzzy
 
 # git revision of dotfiles to install
-devbox_dotfiles_rev: 68ca35463fbb008dd3a784fd5f56c147c6a1f884
+devbox_dotfiles_rev: f2e9dfec0d28b6e2a58ebdaf81de07b3077f49ba


### PR DESCRIPTION
Update the revision of  mrzzy/dotfiles)          embeded in WARP Box with upstream repository to          mrzzy/dotfiles@f2e9dfec0d28b6e2a58ebdaf81de07b3077f49ba