### PR TITLE
refactor(box): Replace apt-key as its use is deprecated

### DIFF
--- a/box/ansible/roles/cloud/tasks/main.yaml
+++ b/box/ansible/roles/cloud/tasks/main.yaml
@@ -5,21 +5,26 @@
 #
 
 # HashiCorp Tools
-- name: "Register HashiCorp's package signing key"
-  become: true
-  apt_key:
-    url: https://apt.releases.hashicorp.com/gpg
-    state: present
+- name: Setup HashiCorp's APT package Repository
+  vars:
+    key_path: /etc/apt/keyrings/hashicorp.gpg
+  block:
+    - name: "Register HashiCorp's package signing key"
+      become: true
+      ansible.builtin.get_url:
+        url: https://apt.releases.hashicorp.com/gpg
+        dest: "{{ key_path }}"
+        mode: 0644
 
-- name: "Add HashiCorp's APT package repository"
-  become: true
-  apt_repository:
-    repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
-    state: present
+    - name: Add HashiCorp's APT package repository
+      become: true
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64 signed-by={{ key_path }}] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+        state: present
 
 - name: Install Cloud tools with APT
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ item }}"
     state: present
   loop:
@@ -31,7 +36,7 @@
 
 - name: Install Cloud tools with Pip
   become: true
-  pip:
+  ansible.builtin.pip:
     name: "{{ item }}"
     state: present
   loop:
@@ -46,7 +51,7 @@
     infracost_binary: /usr/local/bin/infracost-linux-amd64
   block:
     - name: Download Infracost binary
-      unarchive:
+      ansible.builtin.unarchive:
         remote_src: true
         src: "https://github.com/infracost/infracost/releases/download/\
               {{ devbox_infracost_version }}/infracost-linux-amd64.tar.gz"
@@ -55,7 +60,7 @@
         mode: 0755
 
     - name: Strip suffix from Infracost binary
-      command:
+      ansible.builtin.command:
         cmd: "mv {{ infracost_binary }} /usr/local/bin/infracost"
         removes: "{{ infracost_binary }}"
         creates: /usr/local/bin/infracost"

--- a/box/ansible/roles/cloud/tasks/main.yaml
+++ b/box/ansible/roles/cloud/tasks/main.yaml
@@ -7,7 +7,7 @@
 # HashiCorp Tools
 - name: Setup HashiCorp's APT package Repository
   vars:
-    key_path: /etc/apt/keyrings/hashicorp.gpg
+    key_path: /etc/apt/keyrings/hashicorp.asc
   block:
     - name: "Register HashiCorp's package signing key"
       become: true

--- a/box/ansible/roles/k8s/tasks/main.yaml
+++ b/box/ansible/roles/k8s/tasks/main.yaml
@@ -6,7 +6,7 @@
 
 - name: Install Kubectl
   become: true
-  get_url:
+  ansible.builtin.get_url:
     url: "https://dl.k8s.io/release/{{ devbox_kubectl_version }}/bin/linux/amd64/kubectl"
     dest: /usr/local/bin/kubectl
     mode: 0755
@@ -15,42 +15,42 @@
   become: true
   block:
     - name: Add GCP APT Package Signing Key
-      apt_key:
+      ansible.builtin.apt_key:
         url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
         keyring: /usr/share/keyrings/cloud.google.gpg
         state: present
     - name: Add GCP APT Package Repository
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
                https://packages.cloud.google.com/apt cloud-sdk main"
         filename: google-cloud-sdk
         state: present
     - name: Install GKE Auth Plugin
-      apt:
+      ansible.builtin.apt:
         name: "google-cloud-sdk-gke-gcloud-auth-plugin"
         state: present
 
 - name: Install Helm form Third-Party Balto repository
   block:
     - name: "Download Balto's package signing key"
-      get_url:
+      ansible.builtin.get_url:
         url: https://baltocdn.com/helm/signing.asc
         dest: /tmp/baltocdn_key
 
     - name: "Register Balto's package signing key"
       become: true
-      command: apt-key add /tmp/baltocdn_key
+      ansible.builtin.command: apt-key add /tmp/baltocdn_key
       register: hashicorp_key
       changed_when: "hashicorp_key.rc == 0"
 
     - name: "Add Balto's APT package repository"
       become: true
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb https://baltocdn.com/helm/stable/debian/ all main"
         state: present
 
     - name: "Install Helm from Balto's APT package repository"
       become: true
-      apt:
+      ansible.builtin.apt:
         name: "helm={{ devbox_helm_version }}-1"
         state: present

--- a/box/ansible/roles/k8s/tasks/main.yaml
+++ b/box/ansible/roles/k8s/tasks/main.yaml
@@ -12,16 +12,18 @@
     mode: 0755
 
 - name: Install GKE Auth Plugin for Kubectl
+  vars:
+    key_path: /etc/apt/keyrings/cloud.google.gpg
   become: true
   block:
     - name: Add GCP APT Package Signing Key
-      ansible.builtin.apt_key:
+      ansible.builtin.get_url:
         url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-        keyring: /usr/share/keyrings/cloud.google.gpg
-        state: present
+        dest: "{{ key_path }}"
+        mode: 0644
     - name: Add GCP APT Package Repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
+        repo: "deb [signed-by={{ key_path }}] \
                https://packages.cloud.google.com/apt cloud-sdk main"
         filename: google-cloud-sdk
         state: present
@@ -31,22 +33,19 @@
         state: present
 
 - name: Install Helm form Third-Party Balto repository
+  vars:
+    key_path: /etc/apt/keyrings/baltocdn.asc
   block:
     - name: "Download Balto's package signing key"
       ansible.builtin.get_url:
         url: https://baltocdn.com/helm/signing.asc
-        dest: /tmp/baltocdn_key
-
-    - name: "Register Balto's package signing key"
-      become: true
-      ansible.builtin.command: apt-key add /tmp/baltocdn_key
-      register: hashicorp_key
-      changed_when: "hashicorp_key.rc == 0"
+        dest: "{{ key_path }}"
+        mode: 0644
 
     - name: "Add Balto's APT package repository"
       become: true
       ansible.builtin.apt_repository:
-        repo: "deb https://baltocdn.com/helm/stable/debian/ all main"
+        repo: "deb [signed-by={{ key_path }}] https://baltocdn.com/helm/stable/debian/ all main"
         state: present
 
     - name: "Install Helm from Balto's APT package repository"

--- a/box/ansible/roles/k8s/tasks/main.yaml
+++ b/box/ansible/roles/k8s/tasks/main.yaml
@@ -37,6 +37,7 @@
     key_path: /etc/apt/keyrings/baltocdn.asc
   block:
     - name: "Download Balto's package signing key"
+      become: true
       ansible.builtin.get_url:
         url: https://baltocdn.com/helm/signing.asc
         dest: "{{ key_path }}"

--- a/box/ansible/roles/pop_desktop/meta/main.yaml
+++ b/box/ansible/roles/pop_desktop/meta/main.yaml
@@ -1,0 +1,8 @@
+#
+# WARP
+# PopOS Desktop Ansible Role
+# Role Metadata
+#
+
+dependencies:
+  - role: system

--- a/box/ansible/roles/pop_desktop/tasks/main.yaml
+++ b/box/ansible/roles/pop_desktop/tasks/main.yaml
@@ -12,6 +12,7 @@
       become: true
       ansible.builtin.command:
         cmd: "gpg --no-default-keyring \
+          --homedir /tmp \
           --keyring {{ key_path }} \
           --keyserver keyserver.ubuntu.com \
           --recv-keys 63C46DF0140D738961429F4E204DD8AEC33A7AFF"

--- a/box/ansible/roles/pop_desktop/tasks/main.yaml
+++ b/box/ansible/roles/pop_desktop/tasks/main.yaml
@@ -4,24 +4,32 @@
 # Role Tasks
 #
 
-- name: Add PopOS APT Repository signing Key
-  become: true
-  ansible.builtin.apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: 63C46DF0140D738961429F4E204DD8AEC33A7AFF
+- name: Setup PopOS APT Repository
+  vars:
+    key_path: /etc/apt/keyrings/popos.gpg
+  block:
+    - name: Add PopOS APT Repository signing Key
+      become: true
+      ansible.builtin.command:
+        cmd: "gpg --no-default-keyring \
+          --keyring {{ key_path }} \
+          --keyserver keyserver.ubuntu.com \
+          --recv-keys 63C46DF0140D738961429F4E204DD8AEC33A7AFF"
+        creates: "{{ key_path }}"
 
-- name: Register PopOS APT Repository
-  become: true
-  ansible.builtin.copy:
-    content: |
-      X-Repolib-Name: Pop_OS Release Sources
-      Enabled: yes
-      Types: deb deb-src
-      URIs: https://apt.pop-os.org/release
-      Suites: jammy
-      Components: main
-    dest: /etc/apt/sources.list.d/pop-os-release.sources
-    mode: 0644
+    - name: Register PopOS APT Repository
+      become: true
+      ansible.builtin.copy:
+        content: |
+          X-Repolib-Name: Pop_OS Release Sources
+          Enabled: yes
+          Types: deb deb-src
+          URIs: https://apt.pop-os.org/release
+          Suites: jammy
+          Components: main
+          Signed-By: {{ key_path }}
+        dest: /etc/apt/sources.list.d/pop-os-release.sources
+        mode: 0644
 
 - name: Install pop-desktop with APT
   become: true

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -16,5 +16,3 @@ devbox_git_version: "1:2.34.1-1ubuntu1.6"
 # needed to authenticate packages from third-party repositories
 # renovate: datasource=repology depName=ubuntu_22_04/gpg
 devbox_gpg_version: "2.2.27-3ubuntu2.1"
-# renovate: datasource=repology depName=ubuntu_22_04/dirmngr
-devbox_dirmngr_version: "2.2.27-3ubuntu2.1"

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -13,3 +13,6 @@ devbox_acl_version: 2.3.1-1
 # needed for ansible's git module
 # renovate: datasource=repology depName=ubuntu_22_04/git
 devbox_git_version: "1:2.34.1-1ubuntu1.6"
+# needed to authenticate packages from third-party repositories
+# renovate: datasource=repology depName=ubuntu_22_04/gpg
+devbox_gpg_version: "2.2.27-3ubuntu2.1"

--- a/box/ansible/roles/system/defaults/main.yaml
+++ b/box/ansible/roles/system/defaults/main.yaml
@@ -16,3 +16,5 @@ devbox_git_version: "1:2.34.1-1ubuntu1.6"
 # needed to authenticate packages from third-party repositories
 # renovate: datasource=repology depName=ubuntu_22_04/gpg
 devbox_gpg_version: "2.2.27-3ubuntu2.1"
+# renovate: datasource=repology depName=ubuntu_22_04/dirmngr
+devbox_dirmngr_version: "2.2.27-3ubuntu2.1"

--- a/box/ansible/roles/system/tasks/main.yaml
+++ b/box/ansible/roles/system/tasks/main.yaml
@@ -14,6 +14,7 @@
     - "acl={{ devbox_acl_version }}"
     - "git={{ devbox_git_version }}"
     - "gpg={{ devbox_gpg_version }}"
+    - "dirmngr={{ devbox_dirmngr_version }}"
 
 - name: Register alacritty's terminfo with known Terminal Types
   vars:

--- a/box/ansible/roles/system/tasks/main.yaml
+++ b/box/ansible/roles/system/tasks/main.yaml
@@ -6,25 +6,26 @@
 
 - name: Install System utilities with APT
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ item }}"
     state: present
   loop:
     - "software-properties-common={{ devbox_software_properties_version }}"
     - "acl={{ devbox_acl_version }}"
     - "git={{ devbox_git_version }}"
+    - "gpg={{ devbox_gpg_version }}"
 
 - name: Register alacritty's terminfo with known Terminal Types
   vars:
     terminfo_path: /tmp/alacritty.info
   block:
     - name: Download alacritty's terminfo
-      get_url:
+      ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/alacritty/alacritty/master/extra/alacritty.info
         dest: "{{ terminfo_path }}"
         mode: 0644
     - name: Register alacritty's terminfo with database
       become: true
-      command:
+      ansible.builtin.command:
         cmd: "tic -x {{ terminfo_path }}"
         creates: /etc/terminfo/a/alacritty

--- a/box/ansible/roles/system/tasks/main.yaml
+++ b/box/ansible/roles/system/tasks/main.yaml
@@ -14,7 +14,6 @@
     - "acl={{ devbox_acl_version }}"
     - "git={{ devbox_git_version }}"
     - "gpg={{ devbox_gpg_version }}"
-    - "dirmngr={{ devbox_dirmngr_version }}"
 
 - name: Register alacritty's terminfo with known Terminal Types
   vars:


### PR DESCRIPTION
# Motivation
`apt-key` deprecation:
```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```

# Contents
Replace all usage of `apt_key` Ansible module:
- replace usage of `apt_key` to download gpg directly from URL with `get_url`.
- replace usage of `apt_key` to import key from GPG keyserver by running gpg command to recv key directly. 