### PR TITLE
perf(ci): Vagrant CI Job time limit exceed by installing minimum Ubuntu Desktop 

### DIFF
--- a/box/ansible/roles/alacritty/defaults/main.yaml
+++ b/box/ansible/roles/alacritty/defaults/main.yaml
@@ -4,7 +4,7 @@
 # Default Variables
 #
 
-# renovate: datasource=github-releases depName=alacritty/alacritty
-devbox_alacritty_version: 0.11.0
+# renovate: datasource=repology depName=ubuntu_22_04/alacritty
+devbox_alacritty_version: 0.11.0~1667493629~22.04~50c7d78
 # renovate: datasource=github-releases depName=rajasegar/alacritty-themes
 devbox_alacritty_themes_version: 5.3.0

--- a/box/ansible/roles/alacritty/tasks/main.yaml
+++ b/box/ansible/roles/alacritty/tasks/main.yaml
@@ -4,36 +4,11 @@
 # Tasks
 #
 
-- name: Install Alacritty build dependencies
+- name: Install Alacritty with APT
   become: true
   ansible.builtin.apt:
-    name: "{{ item }}"
+    name: "alacritty={{ devbox_alacritty_version }}"
     state: present
-  loop:
-    - libfreetype6-dev
-    - libfontconfig1-dev
-    - libxcb-xfixes0-dev
-
-- name: Build & Install Alacritty terminal
-  vars:
-    cargo_bin: "{{ devbox_user_home }}/.cargo/bin"
-  environment:
-    PATH: "{{ cargo_bin }}:{{ ansible_env.PATH }}"
-  block:
-    - name: Build Alacritty terminal with Cargo
-      become: true
-      become_user: "{{ devbox_user }}"
-      ansible.builtin.command:
-        cmd: "cargo install alacritty@{{ devbox_alacritty_version }}"
-        creates: "{{ cargo_bin }}/alacritty"
-
-    - name: Install Alacritty binary
-      become: true
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ cargo_bin }}/alacritty"
-        dest: /usr/local/bin/alacritty
-        mode: '0755'
 
 - name: Register Alacritty as the default X Terminal emulator
   become: true

--- a/box/ansible/roles/alacritty/tasks/main.yaml
+++ b/box/ansible/roles/alacritty/tasks/main.yaml
@@ -15,7 +15,7 @@
   community.general.alternatives:
     name: x-terminal-emulator
     link: /usr/bin/x-terminal-emulator
-    path: /usr/local/bin/alacritty
+    path: /usr/bin/alacritty
     state: selected
 
 - name: Install Alacritty themes switcher with NPM


### PR DESCRIPTION
## Purpose
Vagrant CI Job is getting `SIGKILL`-ed, likely due to time limits imposed on CI jobs as it runs for >3hr without completion.

## Contents
Fix Vagrant CI Job time limit exceed by:
-  Building alacritty from source is an intensive operation that also contributes to the long build times. Install alacritty as pre-built binaries instead to counter long build times.