### PR TITLE
fix(ci): Downgrade build-box-vagrant job to macos-11 runner

### DIFF
--- a/.github/workflows/box.yaml
+++ b/.github/workflows/box.yaml
@@ -28,7 +28,7 @@ jobs:
     # needed by virtualbox vm to run within github actions runner.
     # it also comes with vagrant & virtualbox preinstalled
     # https://github.com/jonashackt/vagrant-github-actions
-    runs-on: macos-12
+    runs-on: macos-11
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
# Motivation
Attempt to fix error: SSH Port was not properly retrieved from SSHConfig issue.

Only observed difference between failing and passing run is slight difference in runner versions:
- [Failing Run](https://github.com/mrzzy/warp/actions/runs/6569481286/job/17847947216#step:7:132)
- [Passing Run](https://github.com/mrzzy/warp/actions/runs/6569154594/job/17844619197)

# Contents
Rolls back runner to `macos-11` from `macos-12` in attempt to fix issue.